### PR TITLE
Allow an explicit temp directory to be supplied during download

### DIFF
--- a/hdfs/client.py
+++ b/hdfs/client.py
@@ -421,7 +421,7 @@ class Client(object):
     return reader()
 
   def download(self, hdfs_path, local_path, overwrite=False, n_threads=-1,
-    **kwargs):
+               temp_dir=None, **kwargs):
     """Download a (potentially distributed) file from HDFS and save it locally.
     This method returns the local path corresponding to the downloaded file or
     directory.
@@ -432,6 +432,7 @@ class Client(object):
     :param n_threads: Number of threads to use for parallel downloading of
       part-files. A value of `None` or `1` indicates that parallelization won't
       be used; `-1` uses as many threads as there are part-files.
+    :param temp_dir: Used to explicitly set a temp directory used
     :param \*\*kwargs: Keyword arguments forwarded to :meth:`read`.
 
     """
@@ -452,7 +453,7 @@ class Client(object):
       if osp.isfile(_local_path) and not overwrite:
         raise HdfsError('A local file already exists at %s.', _local_path)
       else:
-        with temppath() as tpath:
+        with temppath(dir=temp_dir) as tpath:
           os.mkdir(tpath)
           _temp_path = osp.join(tpath, posixpath.basename(_hdfs_path))
           # ensure temp filename is the same as the source name to ensure
@@ -495,7 +496,7 @@ class Client(object):
         # fail now instead of after the download
       else:
         # remote path is a distributed file and we are writing to a directory
-        with temppath() as tpath:
+        with temppath(dir=temp_dir) as tpath:
           _temp_dir_path = osp.join(tpath, posixpath.basename(hdfs_path))
           os.makedirs(_temp_dir_path)
           # similarly to above, we add an extra directory to ensure that the

--- a/hdfs/util.py
+++ b/hdfs/util.py
@@ -140,8 +140,10 @@ class Config(object):
 
 
 @contextmanager
-def temppath():
+def temppath(dir=None):
   """Create a temporary path.
+
+  :param dir: Explicit dir name to create the temp file in
 
   Usage::
 
@@ -152,7 +154,7 @@ def temppath():
   afterwards.
 
   """
-  (desc, path) = mkstemp()
+  (desc, path) = mkstemp(dir=dir)
   close(desc)
   remove(path)
   try:


### PR DESCRIPTION
I've run into a situation where the default tmp space on a server I'm using the HDFS client on is very small and I have no way to influence its size. The files I'm fetching from HDFS are large enough that I routinely see tracebacks like the following.

```
Traceback (most recent call last):  
  File "/usr/lib64/python2.6/multiprocessing/process.py", line 232, in _bootstrap  
    self.run()  
  File "/usr/lib64/python2.6/multiprocessing/process.py", line 88, in run  
    self._target(*self._args, **self._kwargs)  
  File "/export/content/lid/apps/bizoencrypter/bc8eae0055fe65af639468106d94f2a30c96c5e9/lib/python2.6/site-packages/bizoencrypter/worker.py", line 133, in wrap_target  
    target(*args, **kwargs)  
  File "/export/content/lid/apps/bizoencrypter/bc8eae0055fe65af639468106d94f2a30c96c5e9/lib/python2.6/site-packages/bizoencrypter/worker.py", line 410, in hdfs_worker  
    client.download(path, local_path, overwrite=True)  
  File "/export/content/lid/apps/bizoencrypter/bc8eae0055fe65af639468106d94f2a30c96c5e9/lib/python2.6/site-packages/hdfs/client.py", line 486, in download  
_download((hdfs_path, local_path))  
  File "/export/content/lid/apps/bizoencrypter/bc8eae0055fe65af639468106d94f2a30c96c5e9/lib/python2.6/site-packages/hdfs/client.py", line 469, in _download  
    move(_temp_path, _local_path) # consistent with `mv` behavior  
  File "/usr/lib64/python2.6/contextlib.py", line 34, in __exit__  
    self.gen.throw(type, value, traceback)  
  File "/export/content/lid/apps/bizoencrypter/bc8eae0055fe65af639468106d94f2a30c96c5e9/lib/python2.6/site-packages/hdfs/util.py", line 160, in temppath  
yield path  
  File "/export/content/lid/apps/bizoencrypter/bc8eae0055fe65af639468106d94f2a30c96c5e9/lib/python2.6/site-packages/hdfs/client.py", line 464, in _download  
    writer.write(chunk)  
IOError: [Errno 28] No space left on device
```

This change allows one to specify an explicit directory to be used as temp space.
