### PR TITLE
HttpFS require a content-type header for PUT/POST requests

### DIFF
--- a/hdfs/client.py
+++ b/hdfs/client.py
@@ -342,7 +342,8 @@ class Client(object):
       replication=replication,
       buffersize=buffersize,
     )
-    res_2 = rq.put(res_1.headers['location'], data=data)
+    res_2 = rq.put(res_1.headers['location'], data=data,
+                   headers={'content-type': 'application/octet-stream'})
     if not res_2:
       _on_error(res_2)
 
@@ -359,7 +360,8 @@ class Client(object):
       hdfs_path,
       buffersize=buffersize,
     )
-    res_2 = rq.post(res_1.headers['location'], data=data)
+    res_2 = rq.post(res_1.headers['location'], data=data,
+                    headers={'content-type': 'application/octet-stream'})
     if not res_2:
       _on_error(res_2)
 


### PR DESCRIPTION
My understanding is that HttpFS and WebHDFS are intended to be interoperable; webhdfs does not require this content-type header but HttpFS does. 

Testing this would require a touch of work (see https://github.com/pywebhdfs/pywebhdfs/blob/master/tests/test_webhdfs.py), let me know what you prefer. It would be great if we could get this released to PyPI relatively soon!