### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,9 +92,9 @@ most welcome!
 
 .. _HttpFS: http://hadoop.apache.org/docs/current/hadoop-hdfs-httpfs/
 .. _WebHDFS: http://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-hdfs/WebHDFS.html
-.. _read and write Avro files directly from HDFS: http://hdfscli.readthedocs.org/en/latest/api.html#module-hdfs.ext.avro
-.. _load and save Pandas dataframes: http://hdfscli.readthedocs.org/en/latest/api.html#module-hdfs.ext.dataframe
-.. _support Kerberos authenticated clusters: http://hdfscli.readthedocs.org/en/latest/api.html#module-hdfs.ext.kerberos
-.. _documentation: http://hdfscli.readthedocs.org/
-.. _quickstart: http://hdfscli.readthedocs.org/en/latest/quickstart.html
+.. _read and write Avro files directly from HDFS: https://hdfscli.readthedocs.io/en/latest/api.html#module-hdfs.ext.avro
+.. _load and save Pandas dataframes: https://hdfscli.readthedocs.io/en/latest/api.html#module-hdfs.ext.dataframe
+.. _support Kerberos authenticated clusters: https://hdfscli.readthedocs.io/en/latest/api.html#module-hdfs.ext.kerberos
+.. _documentation: https://hdfscli.readthedocs.io/
+.. _quickstart: https://hdfscli.readthedocs.io/en/latest/quickstart.html
 .. _issues: https://github.com/mtth/hdfs/issues

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
   long_description=_get_long_description(),
   author='Matthieu Monsch',
   author_email='monsch@alum.mit.edu',
-  url='http://hdfscli.readthedocs.org',
+  url='https://hdfscli.readthedocs.io',
   license='MIT',
   packages=find_packages(),
   classifiers=[


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.