### PR TITLE
attempt at get_acl_status

### DIFF
--- a/etc/hadoop/hdfs-site.xml
+++ b/etc/hadoop/hdfs-site.xml
@@ -11,4 +11,8 @@
     <name>dfs.webhdfs.enabled</name>
     <value>true</value>
   </property>
+  <property>
+    <name>dfs.namenode.acls.enabled</name>
+  <value>true</value>
+</property>
 </configuration>

--- a/hdfs/client.py
+++ b/hdfs/client.py
@@ -192,6 +192,7 @@ class Client(object):
   _get_file_status = _Request('GET')
   _get_home_directory = _Request('GET')
   _list_status = _Request('GET')
+  _get_acl_status = _Request('GET')
   _mkdirs = _Request('PUT')
   _open = _Request('GET', stream=True)
   _rename = _Request('PUT')
@@ -276,6 +277,21 @@ class Client(object):
     _logger.info('Fetching status for %r.', hdfs_path)
     res = self._get_file_status(hdfs_path, strict=strict)
     return res.json()['FileStatus'] if res else None
+
+  def get_acl(self, hdfs_path, strict=True):
+    """Get AclStatus_ for a file or folder on HDFS.
+
+    :param hdfs_path: Remote path.
+    :param strict: If `False`, return `None` rather than raise an exception if
+      the path doesn't exist.
+
+    .. _AclStatus: ACLS_
+    .. _ACLS: https://hadoop.apache.org/docs/stable2/hadoop-project-dist/hadoop-hdfs/WebHDFS.html#Get_ACL_Status
+
+    """
+    _logger.info('Fetching ACL status for %r.', hdfs_path)
+    res = self._get_acl_status(hdfs_path, strict=strict)
+    return res.json()['GETACLSTATUS'] if res else None
 
   def parts(self, hdfs_path, parts=None, status=False):
     """Returns a dictionary of part-files corresponding to a path.

--- a/hdfs/client.py
+++ b/hdfs/client.py
@@ -278,7 +278,7 @@ class Client(object):
     res = self._get_file_status(hdfs_path, strict=strict)
     return res.json()['FileStatus'] if res else None
 
-  def get_acl(self, hdfs_path, strict=True):
+  def acl_status(self, hdfs_path, strict=True):
     """Get AclStatus_ for a file or folder on HDFS.
 
     :param hdfs_path: Remote path.
@@ -291,7 +291,7 @@ class Client(object):
     """
     _logger.info('Fetching ACL status for %r.', hdfs_path)
     res = self._get_acl_status(hdfs_path, strict=strict)
-    return res.json()['GETACLSTATUS'] if res else None
+    return res.json()['AclStatus'] if res else None
 
   def parts(self, hdfs_path, parts=None, status=False):
     """Returns a dictionary of part-files corresponding to a path.

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -913,6 +913,27 @@ class TestContent(_IntegrationTest):
   def test_missing_non_strict(self):
     ok_(self.client.content('foo', strict=False) is None)
 
+class TestAcl(_IntegrationTest):
+
+  def test_directory(self):
+    self.client.write('foo', 'hello, world!')
+    content = self.client.acl_status('')
+    ok_(len(content) > 1)
+    ok_(content['entries'] is not None)
+
+  def test_file(self):
+    self.client.write('foo', 'hello, world!')
+    content = self.client.acl_status('foo')
+    ok_(len(content) > 1)
+    ok_(content['entries'] is not None)
+
+  @raises(HdfsError)
+  def test_missing(self):
+    self.client.acl_status('foo')
+
+  def test_missing_non_strict(self):
+    ok_(self.client.acl_status('foo', strict=False) is None)
+
 
 class TestList(_IntegrationTest):
 

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -919,7 +919,9 @@ class TestAcl(_IntegrationTest):
     self.client.write('foo', 'hello, world!')
     content = self.client.acl_status('')
     ok_(len(content) > 1)
-    ok_(content['entries'] is not None)
+    ok_('entries' in content)
+    ok_('group' in content)
+    ok_('owner' in content)
 
   def test_file(self):
     self.client.write('foo', 'hello, world!')


### PR DESCRIPTION
I still have not tested this yet on my cluster. Will definitely try it
tomorrow. Will have to find a way to edit the script directly on the
installed package.

What do you think? (I need the `AclStatus.entries` array, as defined in: [Here](https://hadoop.apache.org/docs/stable2/hadoop-project-dist/hadoop-hdfs/WebHDFS.html#Get_ACL_Status))