### PR TITLE
Update classifiers to match Travis CI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
     'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3.3',
     'Programming Language :: Python :: 3.4',
+    'Programming Language :: Python :: 3.5',
   ],
   install_requires=[
     'docopt',


### PR DESCRIPTION
Travis CI tests Python version 2.6-2.7 and 3.3-3.5.

All are in Trove classifiers except for 3.5, so add it.