### PR TITLE
fix memory leak when using ThreadPool

### DIFF
--- a/hdfs/client.py
+++ b/hdfs/client.py
@@ -1125,6 +1125,10 @@ def _map_async(pool_size, func, args):
   """
   pool = ThreadPool(pool_size)
   if sys.version_info <= (2, 6):
-    return pool.map(func, args)
+    results = pool.map(func, args)
   else:
-    return pool.map_async(func, args).get(1 << 24) # 6+ months.
+    results = pool.map_async(func, args).get(1 << 24) # 6+ months.
+  
+  pool.close()
+  pool.join()
+  return results


### PR DESCRIPTION
This memory leak problem can be reproduced by the following code:
``` python 
import os
import gc
import psutil

process = psutil.Process(os.getpid())
print(process.memory_info().rss)  # in bytes


for i in range(10):
    res = _map_async(4, lambda x:x+1, [1,2,3,4])

    gc.collect()
    process = psutil.Process(os.getpid())
    print(process.memory_info().rss)  # in bytes

```