### PR TITLE
Adding __iter__ attribute to AsyncWriter for pandas compatibility

### DIFF
--- a/hdfs/util.py
+++ b/hdfs/util.py
@@ -55,6 +55,7 @@ class AsyncWriter(object):
     self._queue = None
     self._reader = None
     self._err = None
+    self.__iter__ = None # __iter__ attribute expected by pandas to write csv file since version 0.24.
     _logger.debug('Instantiated %r.', self)
 
   def __repr__(self):
@@ -114,10 +115,6 @@ class AsyncWriter(object):
 
     """
     return False
-
-  def __iter__(self):
-    """Implement __iter__ method expected by pandas to write csv file since version 0.24. """
-    return
 
   def tell(self):
     """No-op implementation."""

--- a/hdfs/util.py
+++ b/hdfs/util.py
@@ -115,6 +115,10 @@ class AsyncWriter(object):
     """
     return False
 
+  def __iter__(self):
+    """Implement __iter__ method expected by pandas to write csv file since version 0.24. """
+    return
+
   def tell(self):
     """No-op implementation."""
     return 0

--- a/hdfs/util.py
+++ b/hdfs/util.py
@@ -50,12 +50,14 @@ class AsyncWriter(object):
 
   """
 
+  # Expected by pandas to write csv files (https://github.com/mtth/hdfs/pull/130).
+  __iter__ = None
+
   def __init__(self, consumer):
     self._consumer = consumer
     self._queue = None
     self._reader = None
     self._err = None
-    self.__iter__ = None # __iter__ attribute expected by pandas to write csv file since version 0.24.
     _logger.debug('Instantiated %r.', self)
 
   def __repr__(self):


### PR DESCRIPTION
Since pandas 0.24 writing a dataframe to a csv file on hdfs like this :
`with client_hdfs.write('path', encoding = 'utf-8', overwrite=True) as writer:
	dataframe.to_csv(writer)`
 raises this error: 
ValueError: Invalid file path or buffer object type: <class 'hdfs.util.AsyncWriter'>

Its because pandas changed in v0.24 its Dataframe.to_csv method and now there is a check for the given filepath_or_buffer to be file like. The check is done by looking for the `__iter__` method.
https://github.com/pandas-dev/pandas/blob/8ff488ac1078c49a0db23562db41dae9e41b053b/pandas/core/dtypes/inference.py#L152

An empty `__iter__` method avoids this error.