### PR TITLE
Use unittest.mock where available

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -14,7 +14,10 @@
 
 import os
 import sys
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 MOCK_MODULES = ['fastavro', 'pandas', 'requests_kerberos']
 for mod_name in MOCK_MODULES:

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,4 @@
 avro
 docopt
 requests>=2.0.1
-mock
+mock;python_version<"3.3"


### PR DESCRIPTION
In Python 3.3 and later, `unittest.mock` belongs to the standard library, and the PyPI backport module `mock` is not needed.