### PR TITLE
add possibility to remove acl entries

### DIFF
--- a/hdfs/client.py
+++ b/hdfs/client.py
@@ -228,6 +228,9 @@ class Client(object):
   _list_status = _Request('GET')
   _mkdirs = _Request('PUT')
   _modify_acl_entries = _Request('PUT')
+  _remove_acl_entries = _Request('PUT')
+  _remove_default_acl = _Request('PUT')
+  _remove_acl = _Request('PUT')
   _open = _Request('GET', stream=True)
   _rename = _Request('PUT')
   _set_acl = _Request('PUT')
@@ -358,6 +361,48 @@ class Client(object):
     else:
       _logger.info('Modifying ACL spec for %r to %r.', hdfs_path, acl_spec)
       self._modify_acl_entries(hdfs_path, aclspec=acl_spec)
+
+  def remove_acl_entries(self, hdfs_path, acl_spec):
+    """RemoveACL_ for a file or folder on HDFS.
+
+    :param hdfs_path: Path to an existing remote file or directory. An
+      :class:`HdfsError` will be raised if the path doesn't exist.
+    :param acl_spec: String representation of an ACL spec. Must be a valid
+      string with entries for user, group and other. For example:
+      `"user::rwx,user:foo:rw-,group::r--,other::---"`.
+
+    .. _RemoveAcl: REMOVEACLENTRIES_
+    .. REMOVEACLENTRIES_: https://hadoop.apache.org/docs/stable2/hadoop-project-dist/hadoop-hdfs/WebHDFS.html#Remove_ACL_Entries
+
+    """
+    _logger.info('Removing ACL spec on %r for %r.', hdfs_path, acl_spec)
+    self._remove_acl_entries(hdfs_path, aclspec=acl_spec)
+
+  def remove_default_acl(self, hdfs_path):
+    """RemoveDefaultACL_ for a file or folder on HDFS.
+
+        :param hdfs_path: Path to an existing remote file or directory. An
+          :class:`HdfsError` will be raised if the path doesn't exist.
+
+        .. _RemoveDefaultAcl: REMOVEDEFAULTACL_
+        .. REMOVEDEFAULTACL_: https://hadoop.apache.org/docs/stable2/hadoop-project-dist/hadoop-hdfs/WebHDFS.html#Remove_Default_ACL
+
+        """
+    _logger.info('Removing default acl for %r', hdfs_path)
+    self._remove_default_acl(hdfs_path)
+
+  def remove_acl(self, hdfs_path):
+    """RemoveACL_ for a file or folder on HDFS.
+
+        :param hdfs_path: Path to an existing remote file or directory. An
+          :class:`HdfsError` will be raised if the path doesn't exist.
+
+        .. _RemoveAcl: REMOVEACL_
+        .. REMOVEACL_: https://hadoop.apache.org/docs/stable2/hadoop-project-dist/hadoop-hdfs/WebHDFS.html#Remove_ACL
+
+        """
+    _logger.info('Removing all ACL for %r', hdfs_path)
+    self._remove_acl(hdfs_path)
 
   def parts(self, hdfs_path, parts=None, status=False):
     """Returns a dictionary of part-files corresponding to a path.

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -961,6 +961,27 @@ class TestAcl(_IntegrationTest):
   def test_missing_non_strict(self):
     ok_(self.client.acl_status('foo', strict=False) is None)
 
+  def test_remove_acl_entries(self):
+    self.client.write('foo', 'hello, world!')
+    self.client.set_acl('foo', 'user:baruser:rwx,user:foouser:rw-', clear=False)
+    self.client.remove_acl_entries('foo', 'user:foouser:')
+    content = self.client.acl_status('foo')
+    ok_(not any('user:foouser:rw-' in s for s in content['entries']))
+    ok_(any('user:baruser:rwx' in s for s in content['entries']))
+
+  def test_remove_default_acl(self):
+    self.client.write('foo', 'hello, world!')
+    self.client.set_acl('foo', 'user:foouser:rwx', clear=False)
+    self.client.remove_default_acl('foo')
+    content = self.client.acl_status('foo')
+    ok_(not any('user::rwx' in s for s in content['entries']))
+
+  def test_remove_acl(self):
+    self.client.write('foo', 'hello, world!')
+    self.client.remove_acl('foo')
+    content = self.client.acl_status('foo')
+    eq_(content.get('entries'), [])
+
 
 class TestList(_IntegrationTest):
 


### PR DESCRIPTION
added remove_acl_entries to remove selected acl, remove_default_acl to remove all default acl, and remove_acl to remove all acl.
Also added tests for those methods.
Those methods are defined in https://hadoop.apache.org/docs/stable2/hadoop-project-dist/hadoop-hdfs/WebHDFS.html so should be available everywhere.