### PR TITLE
Run https://github.com/asottile/pyupgrade to fix DeprecationWarnings

### DIFF
--- a/examples/json-example.py
+++ b/examples/json-example.py
@@ -44,7 +44,7 @@ content = client.content('models/1.json')
 # convenient to read CSV files.
 with client.read('models/1.csv', delimiter='\n', encoding='utf-8') as reader:
   items = (line.split(',') for line in reader if line)
-  assert dict((name, float(value)) for name, value in items) == model
+  assert {name: float(value) for name, value in items} == model
 
 # Loading JSON directly from HDFS is even simpler.
 with client.read('models/1.json', encoding='utf-8') as reader:

--- a/hdfs/__main__.py
+++ b/hdfs/__main__.py
@@ -102,7 +102,7 @@ def configure_client(command, args, config=None):
       sys.stdout.write('No log file active.\n')
       sys.exit(1)
     else:
-      sys.stdout.write('%s\n' % (handler.baseFilename, ))
+      sys.stdout.write('{}\n'.format(handler.baseFilename))
       sys.exit(0)
   logger.addHandler(handler)
   return config.get_client(args['--alias'])

--- a/hdfs/client.py
+++ b/hdfs/client.py
@@ -91,7 +91,7 @@ class _Request(object):
           while client._urls[0] in attempted_hosts:
             client._urls.rotate(-1)
           host = client._urls[0]
-        url = '%s%s%s' % (
+        url = '{}{}{}'.format(
           host.rstrip('/'),
           self.webhdfs_prefix,
           quote(client.resolve(hdfs_path), '/= '),
@@ -124,8 +124,8 @@ class _Request(object):
             _logger.warning('No reachable host, raising last error.')
           raise err
 
-    api_handler.__name__ = '%s_handler' % (operation.lower(), )
-    api_handler.__doc__ = 'Cf. %s#%s' % (self.doc_url, operation)
+    api_handler.__name__ = '{}_handler'.format(operation.lower())
+    api_handler.__doc__ = 'Cf. {}#{}'.format(self.doc_url, operation)
     return api_handler
 
 
@@ -192,12 +192,12 @@ class Client(object):
     _logger.info('Instantiated %r.', self)
 
   def __repr__(self):
-    return '<%s(url=%r)>' % (self.__class__.__name__, self.url)
+    return '<{}(url={!r})>'.format(self.__class__.__name__, self.url)
 
   # Generic request handler
 
   def _request(self, method, url, **kwargs):
-    """Send request to WebHDFS API.
+    r"""Send request to WebHDFS API.
 
     :param method: HTTP verb.
     :param url: Url to send the request to.
@@ -271,10 +271,10 @@ class Client(object):
       n = match.group(1) # n as in {N} syntax
       for _ in repeat(None, int(n) if n else 1):
         statuses = self._list_status(psp.join(prefix, suffix)).json()
-        candidates = sorted([
+        candidates = sorted(
           (-status['modificationTime'], status['pathSuffix'])
           for status in statuses['FileStatuses']['FileStatus']
-        ])
+        )
         if not candidates:
           raise HdfsError('Cannot expand #LATEST. %r is empty.', prefix)
         elif len(candidates) == 1 and candidates[0][1] == '':
@@ -378,11 +378,11 @@ class Client(object):
       (name, pattern.match(name), s)
       for name, s in self.list(hdfs_path, status=True)
     )
-    part_files = dict(
-      (int(match.group(1)), (name, s))
+    part_files = {
+      int(match.group(1)): (name, s)
       for name, match, s in matches
       if match
-    )
+    }
     if not part_files:
       raise HdfsError('No part-files found in %r.', hdfs_path)
     _logger.debug('Found %s part-files for %r.', len(part_files), hdfs_path)
@@ -483,7 +483,7 @@ class Client(object):
 
   def upload(self, hdfs_path, local_path, n_threads=1, temp_dir=None,
     chunk_size=2 ** 16, progress=None, cleanup=True, **kwargs):
-    """Upload a file or directory to HDFS.
+    r"""Upload a file or directory to HDFS.
 
     :param hdfs_path: Target HDFS path. If it already exists and is a
       directory, files will be uploaded inside.
@@ -553,7 +553,7 @@ class Client(object):
         raise err
     else:
       # Remote path is a directory.
-      suffixes = set(status['pathSuffix'] for status in statuses)
+      suffixes = {status['pathSuffix'] for status in statuses}
       local_name = osp.basename(local_path)
       hdfs_path = psp.join(hdfs_path, local_name)
       if local_name in suffixes:
@@ -567,7 +567,7 @@ class Client(object):
       temp_dir = temp_dir or remote_dpath
       temp_path = psp.join(
         temp_dir,
-        '%s.temp-%s' % (remote_name, _current_micros())
+        '{}.temp-{}'.format(remote_name, _current_micros())
       )
       _logger.debug(
         'Upload destination %r already exists. Using temporary path %r.',
@@ -722,7 +722,7 @@ class Client(object):
 
   def download(self, hdfs_path, local_path, overwrite=False, n_threads=1,
     temp_dir=None, **kwargs):
-    """Download a file or folder from HDFS and save it locally.
+    r"""Download a file or folder from HDFS and save it locally.
 
     :param hdfs_path: Path on HDFS of the file or folder to download. If a
       folder, all the files under it will be downloaded.
@@ -772,7 +772,7 @@ class Client(object):
       temp_dir = temp_dir or local_dpath
       temp_path = osp.join(
         temp_dir,
-        '%s.temp-%s' % (local_name, _current_micros())
+        '{}.temp-{}'.format(local_name, _current_micros())
       )
       _logger.debug(
         'Download destination %r already exists. Using temporary path %r.',
@@ -919,9 +919,9 @@ class Client(object):
       raise ValueError('Must set at least one of owner or group.')
     messages = []
     if owner:
-      messages.append('owner to %r' % (owner, ))
+      messages.append('owner to {!r}'.format(owner))
     if group:
-      messages.append('group to %r' % (group, ))
+      messages.append('group to {!r}'.format(group))
     _logger.info('Changing %s of %r.', ', and'.join(messages), hdfs_path)
     self._set_owner(hdfs_path, owner=owner, group=group)
 
@@ -949,9 +949,9 @@ class Client(object):
       raise ValueError('At least one of time must be specified.')
     msgs = []
     if access_time:
-      msgs.append('access time to %r' % (access_time, ))
+      msgs.append('access time to {!r}'.format(access_time))
     if modification_time:
-      msgs.append('modification time to %r' % (modification_time, ))
+      msgs.append('modification time to {!r}'.format(modification_time))
     _logger.info('Updating %s of %r.', ' and '.join(msgs), hdfs_path)
     self._set_times(
       hdfs_path,
@@ -1185,7 +1185,7 @@ class Client(object):
 
 class InsecureClient(Client):
 
-  """HDFS web client to use when security is off.
+  r"""HDFS web client to use when security is off.
 
   :param url: Hostname or IP address of HDFS namenode, prefixed with protocol,
     followed by WebHDFS port on namenode
@@ -1209,7 +1209,7 @@ class InsecureClient(Client):
 
 class TokenClient(Client):
 
-  """HDFS web client using Hadoop token delegation security.
+  r"""HDFS web client using Hadoop token delegation security.
 
   :param url: Hostname or IP address of HDFS namenode, prefixed with protocol,
     followed by WebHDFS port on namenode

--- a/hdfs/config.py
+++ b/hdfs/config.py
@@ -82,7 +82,7 @@ class Config(RawConfigParser):
       _logger.info('Instantiated empty configuration.')
 
   def __repr__(self):
-    return '<Config(path=%r)>' % (self.path, )
+    return '<Config(path={!r})>'.format(self.path)
 
   def get_client(self, alias=None):
     """Load HDFS client.
@@ -105,7 +105,7 @@ class Config(RawConfigParser):
       alias = self.get(self.global_section, 'default.alias')
     if not alias in self._clients:
       for suffix in ('.alias', '_alias'):
-        section = '%s%s' % (alias, suffix)
+        section = '{}{}'.format(alias, suffix)
         if self.has_section(section):
           options = dict(self.items(section))
           class_name = options.pop('client', 'InsecureClient')
@@ -129,8 +129,8 @@ class Config(RawConfigParser):
       :class:`TimedRotatingFileHandler`.
 
     """
-    section = '%s.command' % (command, )
-    path = osp.join(gettempdir(), '%s.log' % (command, ))
+    section = '{}.command'.format(command)
+    path = osp.join(gettempdir(), '{}.log'.format(command))
     level = lg.DEBUG
     if self.has_section(section):
       key = 'log.disable'
@@ -156,7 +156,7 @@ class Config(RawConfigParser):
 
     def _load(suffix, loader):
       """Generic module loader."""
-      option = 'autoload.%s' % (suffix, )
+      option = 'autoload.{}'.format(suffix)
       if self.has_option(self.global_section, option):
         entries = self.get(self.global_section, option)
         for entry in entries.split(','):
@@ -179,7 +179,7 @@ class Config(RawConfigParser):
 
 
 def catch(*error_classes):
-  """Returns a decorator that catches errors and prints messages to stderr.
+  r"""Returns a decorator that catches errors and prints messages to stderr.
 
   :param \*error_classes: Error classes.
 

--- a/hdfs/ext/avro/__init__.py
+++ b/hdfs/ext/avro/__init__.py
@@ -82,14 +82,14 @@ class _SchemaInferrer(object):
         raise ValueError('Cannot infer type of empty record.')
       self.record_index += 1
       return {
-        'name': '__Record%s' % (self.record_index, ),
+        'name': '__Record{}'.format(self.record_index),
         'type': 'record',
         'fields': [
           {'name': k, 'type': self.infer(v)}
           for k, v in sorted(obj.items()) # Sort fields by name.
         ]
       }
-    raise ValueError('Cannot infer type from %s: %r' % (type(obj), obj))
+    raise ValueError('Cannot infer type from {}: {!r}'.format(type(obj), obj))
 
 
 class _SeekableReader(object):
@@ -189,7 +189,7 @@ class AvroReader(object):
     _logger.debug('Instantiated %r.', self)
 
   def __repr__(self):
-    return '<AvroReader(paths=%r)>' % (self._paths, )
+    return '<AvroReader(paths={!r})>'.format(self._paths)
 
   def __enter__(self):
 
@@ -239,7 +239,7 @@ class AvroReader(object):
 
 class AvroWriter(object):
 
-  """Write an Avro file on HDFS from python dictionaries.
+  r"""Write an Avro file on HDFS from python dictionaries.
 
   :param client: :class:`hdfs.client.Client` instance.
   :param hdfs_path: Remote path.
@@ -281,7 +281,7 @@ class AvroWriter(object):
     _logger.info('Instantiated %r.', self)
 
   def __repr__(self):
-    return '<AvroWriter(hdfs_path=%r)>' % (self._hdfs_path, )
+    return '<AvroWriter(hdfs_path={!r})>'.format(self._hdfs_path)
 
   def __enter__(self):
     if self._entered:

--- a/hdfs/ext/avro/__main__.py
+++ b/hdfs/ext/avro/__main__.py
@@ -61,7 +61,7 @@ import sys
 
 class _Encoder(JSONEncoder):
 
-  """Custom encoder to support bytes and fixed strings.
+  r"""Custom encoder to support bytes and fixed strings.
 
   :param \*\*kwargs: Keyword arguments forwarded to the base constructor.
 
@@ -116,7 +116,7 @@ def main(argv=None, client=None, stdin=sys.stdin, stdout=sys.stdout):
     reader = AvroReader(client, args['HDFS_PATH'], parts=parts)
     with reader:
       if args['schema']:
-        stdout.write('%s\n' % (dumps(reader.schema, indent=2), ))
+        stdout.write('{}\n'.format(dumps(reader.schema, indent=2)))
       elif args['read']:
         encoder = _Encoder()
         num = parse_arg(args, '--num', int)

--- a/hdfs/ext/dataframe.py
+++ b/hdfs/ext/dataframe.py
@@ -34,7 +34,7 @@ def read_dataframe(client, hdfs_path):
 
 
 def write_dataframe(client, hdfs_path, df, **kwargs):
-  """Save dataframe to HDFS as Avro.
+  r"""Save dataframe to HDFS as Avro.
 
   :param client: :class:`hdfs.client.Client` instance.
   :param hdfs_path: Remote path where the dataframe will be stored.

--- a/hdfs/ext/kerberos.py
+++ b/hdfs/ext/kerberos.py
@@ -79,7 +79,7 @@ class _HdfsHTTPKerberosAuth(requests_kerberos.HTTPKerberosAuth):
 
 class KerberosClient(Client):
 
-  """HDFS web client using Kerberos authentication.
+  r"""HDFS web client using Kerberos authentication.
 
   :param url: Hostname or IP address of HDFS namenode, prefixed with protocol,
     followed by WebHDFS port on namenode.

--- a/hdfs/util.py
+++ b/hdfs/util.py
@@ -61,7 +61,7 @@ class AsyncWriter(object):
     _logger.debug('Instantiated %r.', self)
 
   def __repr__(self):
-    return '<%s(consumer=%r)>' % (self.__class__.__name__, self._consumer)
+    return '<{}(consumer={!r})>'.format(self.__class__.__name__, self._consumer)
 
   def __enter__(self):
     if self._queue:

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
     'dataframe': ['fastavro>=0.21.19', 'pandas>=0.14.1'],
   },
   entry_points={'console_scripts': [
-    '%s = hdfs.__main__:main' % (ENTRY_POINT, ),
-    '%s-avro = hdfs.ext.avro.__main__:main' % (ENTRY_POINT, ),
+    '{} = hdfs.__main__:main'.format(ENTRY_POINT),
+    '{}-avro = hdfs.ext.avro.__main__:main'.format(ENTRY_POINT),
   ]},
 )

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -93,7 +93,7 @@ class TestApi(_IntegrationTest):
     ok_(not self.client._delete(path).json()['boolean'])
 
   def test_rename_file(self):
-    paths = ['foo', '%s/bar' % (self.client.root.rstrip('/'), )]
+    paths = ['foo', '{}/bar'.format(self.client.root.rstrip('/'))]
     self._write(paths[0], b'hello')
     ok_(self.client._rename(paths[0], destination=paths[1]).json()['boolean'])
     ok_(not self._exists(paths[0]))
@@ -101,7 +101,7 @@ class TestApi(_IntegrationTest):
     self.client._delete(paths[1])
 
   def test_rename_file_to_existing(self):
-    p = ['foo', '%s/bar' % (self.client.root.rstrip('/'), )]
+    p = ['foo', '{}/bar'.format(self.client.root.rstrip('/'))]
     self._write(p[0], b'hello')
     self._write(p[1], b'hi')
     try:
@@ -664,7 +664,7 @@ class TestDownload(_IntegrationTest):
       'part-r-00002': b'foo',
     }
     for name, content in parts.items():
-      self._write('dl/%s' % (name, ), content)
+      self._write('dl/{}'.format(name), content)
     with temppath() as tpath:
       self.client.download('dl', tpath, n_threads=-1)
       local_parts = os.listdir(tpath)
@@ -1241,7 +1241,7 @@ class TestChecksum(_IntegrationTest):
   def test_file(self):
     self.client.write('foo', 'hello')
     checksum = self.client.checksum('foo')
-    eq_(set(['algorithm', 'bytes', 'length']), set(checksum))
+    eq_({'algorithm', 'bytes', 'length'}, set(checksum))
 
 
 class TestSetReplication(_IntegrationTest):

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -31,8 +31,8 @@ class _ExamplesType(type):
           # Unmet dependency.
           raise SkipTest
 
-      test.__name__ = 'test_%s' % (module, )
-      test.__doc__ = 'Test for example %s.' % (fpath, )
+      test.__name__ = 'test_{}'.format(module)
+      test.__doc__ = 'Test for example {}.'.format(fpath)
       return test
 
     for fname in os.listdir(mcs.dpath):

--- a/test/test_ext_avro.py
+++ b/test/test_ext_avro.py
@@ -254,7 +254,7 @@ class TestMain(_AvroIntegrationTest):
       'part-m-00001.avro': [{'name': 'john'}, {'name': 'liz'}],
     }
     for fname, records in data.items():
-      with AvroWriter(self.client, 'data.avro/%s' % (fname, )) as writer:
+      with AvroWriter(self.client, 'data.avro/{}'.format(fname)) as writer:
         for record in records:
           writer.write(record)
     with temppath() as tpath:

--- a/test/test_ext_kerberos.py
+++ b/test/test_ext_kerberos.py
@@ -47,4 +47,4 @@ class TestKerberosClient(object):
     t2.start()
     t1.join()
     t2.join()
-    eq_(auth._calls, set([1, 2]))
+    eq_(auth._calls, {1, 2})


### PR DESCRIPTION
Problem:

Regular expressions use the backslash character ('') to indicate special forms or to allow special characters to be used without invoking their special meaning. This collides with Python’s usage of the same character for the same purpose in string literals; for example, to match a literal backslash, one might have to write '\\' as the pattern string, because the regular expression must be \, and each backslash must be expressed as \ inside a regular Python string literal. Also, please note that any invalid escape sequences in Python’s usage of the backslash in string literals now generate a DeprecationWarning and in the future this will become a SyntaxError. This behaviour will happen even if it is a valid escape sequence for a regular expression.

Solution:

The solution is to use Python’s raw string notation for regular expression patterns; backslashes are not handled in any special way in a string literal prefixed with 'r'. So r"\n" is a two-character string containing '' and 'n', while "\n" is a one-character string containing a newline. Usually patterns will be expressed in Python code using this raw string notation.