### PR TITLE
Replace usage of pandas.util.testing with pandas.testing

### DIFF
--- a/test/test_ext_dataframe.py
+++ b/test/test_ext_dataframe.py
@@ -13,7 +13,7 @@ import os.path as osp
 try:
   from hdfs.ext.avro import AvroReader
   from hdfs.ext.dataframe import read_dataframe, write_dataframe
-  from pandas.util.testing import assert_frame_equal
+  from pandas.testing import assert_frame_equal
   import pandas as pd
 except ImportError:
   SKIP = True


### PR DESCRIPTION
The module pandas.util.testing was removed in pandas 2.0.0.

The API of pandas.testing should be the same as pandas.util.testing.

https://pandas.pydata.org/pandas-docs/version/1.5.1/whatsnew/v1.0.0.html#:~:text=The%20pandas.util.testing%20module%20has%20been%20deprecated.%20Use%20the%20public%20API%20in%20pandas.testing%20documented%20at%20Assertion%20functions%20(GH16232).