### PR TITLE
Migrate from nose to pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,11 +51,11 @@ jobs:
           echo "HTTPFS_URL=http://localhost:14000" >>"$GITHUB_ENV"
           sleep 5 # TODO: Find a better way to wait for all datanodes to become reachable.
       - name: Install
-        run: pip install .[avro] coverage mock nose
+        run: pip install .[avro] coverage mock nose pytest pytest-cov
       - name: Test on WebHDFS
-        run: HDFSCLI_TEST_URL="$WEBHDFS_URL" python -m nose --with-coverage --cover-package=hdfs
+        run: HDFSCLI_TEST_URL="$WEBHDFS_URL" python -m pytest --cov=hdfs
       - name: Test on HTTPFS
-        run: HDFSCLI_TEST_URL="$HTTPFS_URL" HDFSCLI_NOSNAPSHOT=1 python -m nose --with-coverage --cover-package=hdfs
+        run: HDFSCLI_TEST_URL="$HTTPFS_URL" HDFSCLI_NOSNAPSHOT=1 python -m pytest --cov=hdfs
       - name: Stop HDFS
         if: always()
         run: ./scripts/hadoop.sh stop

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
           echo "HTTPFS_URL=http://localhost:14000" >>"$GITHUB_ENV"
           sleep 5 # TODO: Find a better way to wait for all datanodes to become reachable.
       - name: Install
-        run: pip install .[avro] coverage mock nose pytest pytest-cov
+        run: pip install .[avro] coverage mock pytest pytest-cov pandas
       - name: Test on WebHDFS
         run: HDFSCLI_TEST_URL="$WEBHDFS_URL" python -m pytest --cov=hdfs
       - name: Test on HTTPFS

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ HdfsCLI is tested against both [WebHDFS][] and [HttpFS][]. There are two ways
 of running tests (see `scripts/` for helpers to set up a test HDFS cluster):
 
 ```sh
-$ HDFSCLI_TEST_URL=http://localhost:50070 nosetests # Using a namenode's URL.
-$ HDFSCLI_TEST_ALIAS=dev nosetests # Using an alias.
+$ HDFSCLI_TEST_URL=http://localhost:50070 pytest # Using a namenode's URL.
+$ HDFSCLI_TEST_ALIAS=dev pytest # Using an alias.
 ```
 
 ## Contributing

--- a/examples/dataframe-example.py
+++ b/examples/dataframe-example.py
@@ -24,4 +24,4 @@ write_dataframe(client, 'data.avro', df, overwrite=True)
 _df = read_dataframe(client, 'data.avro')
 
 # The frames match!
-pd.util.testing.assert_frame_equal(df, _df)
+pd.testing.assert_frame_equal(df, _df)

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -6,7 +6,7 @@
 from collections import defaultdict
 from hdfs.client import *
 from hdfs.util import HdfsError, temppath
-from util import _IntegrationTest
+from test.util import _IntegrationTest
 from requests.exceptions import ConnectTimeout, ReadTimeout
 from shutil import rmtree
 from six import b

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -24,7 +24,7 @@ class TestLoad(object):
 
   def test_bare(self):
     client = Client.from_options({'url': 'foo'})
-    ok_(isinstance(client, Client))
+    assert isinstance(client, Client)
 
   def test_new_type(self):
     class NewClient(Client):
@@ -32,7 +32,7 @@ class TestLoad(object):
         super(NewClient, self).__init__(url)
         self.bar = bar
     client = Client.from_options({'url': 'bar', 'bar': 2}, 'NewClient')
-    eq_(client.bar, 2)
+    assert client.bar == 2
 
   def test_missing_options(self):
     with pytest.raises(HdfsError):
@@ -47,10 +47,10 @@ class TestLoad(object):
       Client.from_options({}, 'MissingClient')
 
   def test_timeout(self):
-    eq_(Client('')._timeout, None)
-    eq_(Client('', timeout=1)._timeout, 1)
-    eq_(Client('', timeout=(1,2))._timeout, (1,2))
-    eq_(Client.from_options({'url': ''})._timeout, None)
+    assert Client('')._timeout == None
+    assert Client('', timeout=1)._timeout == 1
+    assert Client('', timeout=(1,2))._timeout == (1,2)
+    assert Client.from_options({'url': ''})._timeout == None
 
 
 class TestOptions(_IntegrationTest):
@@ -72,33 +72,33 @@ class TestApi(_IntegrationTest):
   """Test client raw API interactions."""
 
   def test_list_status_absolute_root(self):
-    ok_(self.client._list_status('/'))
+    assert self.client._list_status('/')
 
   def test_get_folder_status(self):
     self.client._mkdirs('foo')
     status = self.client._get_file_status('foo').json()['FileStatus']
-    eq_(status['type'], 'DIRECTORY')
+    assert status['type'] == 'DIRECTORY'
 
   def test_get_home_directory(self):
     path = self.client._get_home_directory('/').json()['Path']
-    ok_('/user/' in path)
+    assert '/user/' in path
 
   def test_delete_file(self):
     path = 'bar'
     self._write(path, b'hello')
-    ok_(self.client._delete(path).json()['boolean'])
-    ok_(not self._exists(path))
+    assert self.client._delete(path).json()['boolean']
+    assert not self._exists(path)
 
   def test_delete_missing_file(self):
     path = 'bar2'
-    ok_(not self.client._delete(path).json()['boolean'])
+    assert not self.client._delete(path).json()['boolean']
 
   def test_rename_file(self):
     paths = ['foo', '{}/bar'.format(self.client.root.rstrip('/'))]
     self._write(paths[0], b'hello')
-    ok_(self.client._rename(paths[0], destination=paths[1]).json()['boolean'])
-    ok_(not self._exists(paths[0]))
-    eq_(self.client._open(paths[1].rsplit('/', 1)[1]).content, b'hello')
+    assert self.client._rename(paths[0], destination=paths[1]).json()['boolean']
+    assert not self._exists(paths[0])
+    assert self.client._open(paths[1].rsplit('/', 1)[1]).content == b'hello'
     self.client._delete(paths[1])
 
   def test_rename_file_to_existing(self):
@@ -106,20 +106,20 @@ class TestApi(_IntegrationTest):
     self._write(p[0], b'hello')
     self._write(p[1], b'hi')
     try:
-      ok_(not self.client._rename(p[0], destination=p[1]).json()['boolean'])
+      assert not self.client._rename(p[0], destination=p[1]).json()['boolean']
     finally:
       self.client._delete(p[0])
       self.client._delete(p[1])
 
   def test_open_file(self):
     self._write('foo', b'hello')
-    eq_(self.client._open('foo').content, b'hello')
+    assert self.client._open('foo').content == b'hello'
 
   def test_get_file_checksum(self):
     self._write('foo', b'hello')
     data = self.client._get_file_checksum('foo').json()['FileChecksum']
-    eq_(sorted(data), ['algorithm', 'bytes', 'length'])
-    ok_(int(data['length']))
+    assert sorted(data) == ['algorithm', 'bytes', 'length']
+    assert int(data['length'])
 
   def test_get_file_checksum_on_folder(self):
     with pytest.raises(HdfsError):
@@ -129,19 +129,19 @@ class TestApi(_IntegrationTest):
 class TestResolve(_IntegrationTest):
 
   def test_resolve_relative(self):
-    eq_(Client('url', root='/').resolve('bar'), '/bar')
-    eq_(Client('url', root='/foo').resolve('bar'), '/foo/bar')
-    eq_(Client('url', root='/foo/').resolve('bar'), '/foo/bar')
-    eq_(Client('url', root='/foo/').resolve('bar/'), '/foo/bar')
-    eq_(Client('url', root='/foo/').resolve('/bar/'), '/bar')
+    assert Client('url', root='/').resolve('bar') == '/bar'
+    assert Client('url', root='/foo').resolve('bar') == '/foo/bar'
+    assert Client('url', root='/foo/').resolve('bar') == '/foo/bar'
+    assert Client('url', root='/foo/').resolve('bar/') == '/foo/bar'
+    assert Client('url', root='/foo/').resolve('/bar/') == '/bar'
 
   def test_resolve_relative_no_root(self):
     root = self.client.root
     try:
       self.client.root = None
       home = self.client._get_home_directory('/').json()['Path']
-      eq_(self.client.resolve('bar'), psp.join(home, 'bar'))
-      eq_(self.client.root, home)
+      assert self.client.resolve('bar') == psp.join(home, 'bar')
+      assert self.client.root == home
     finally:
       self.client.root = root
 
@@ -150,14 +150,14 @@ class TestResolve(_IntegrationTest):
     try:
       self.client.root = 'bar'
       home = self.client._get_home_directory('/').json()['Path']
-      eq_(self.client.resolve('foo'), psp.join(home, 'bar', 'foo'))
-      eq_(self.client.root, psp.join(home, 'bar'))
+      assert self.client.resolve('foo') == psp.join(home, 'bar', 'foo')
+      assert self.client.root == psp.join(home, 'bar')
     finally:
       self.client.root = root
 
   def test_resolve_absolute(self):
-    eq_(Client('url').resolve('/bar'), '/bar')
-    eq_(Client('url').resolve('/bar/foo/'), '/bar/foo')
+    assert Client('url').resolve('/bar') == '/bar'
+    assert Client('url').resolve('/bar/foo/') == '/bar/foo'
 
   def test_create_file_with_percent(self):
     # `%` (`0x25`) is a special case because it seems to cause errors (even
@@ -168,28 +168,28 @@ class TestResolve(_IntegrationTest):
       self._write(path, b'hello')
     except HdfsError:
       pass
-    eq_(self._read(path), b'hello')
+    assert self._read(path) == b'hello'
 
 
 class TestWrite(_IntegrationTest):
 
   def test_create_from_string(self):
     self.client.write('up', b'hello, world!')
-    eq_(self._read('up'), b'hello, world!')
+    assert self._read('up') == b'hello, world!'
 
   def test_create_from_string_with_encoding(self):
     self.client.write('up', u'hello, world!', encoding='utf-8')
-    eq_(self._read('up'), b'hello, world!')
+    assert self._read('up') == b'hello, world!'
 
   def test_create_from_generator(self):
     data = (e for e in [b'hello, ', b'world!'])
     self.client.write('up', data)
-    eq_(self._read('up'), b'hello, world!')
+    assert self._read('up') == b'hello, world!'
 
   def test_create_from_generator_with_encoding(self):
     data = (e for e in [u'hello, ', u'world!'])
     self.client.write('up', data, encoding='utf-8')
-    eq_(self._read('up'), b'hello, world!')
+    assert self._read('up') == b'hello, world!'
 
   def test_create_from_file_object(self):
     with temppath() as tpath:
@@ -197,12 +197,12 @@ class TestWrite(_IntegrationTest):
         writer.write('hello, world!')
       with open(tpath) as reader:
         self.client.write('up', reader)
-    eq_(self._read('up'), b'hello, world!')
+    assert self._read('up') == b'hello, world!'
 
   def test_create_set_permission(self):
     self.client.write('up', b'hello, world!', permission='722')
-    eq_(self._read('up'), b'hello, world!')
-    eq_(self.client.status('up')['permission'], '722')
+    assert self._read('up') == b'hello, world!'
+    assert self.client.status('up')['permission'] == '722'
 
   def test_create_to_existing_file_without_overwrite(self):
     with pytest.raises(HdfsError):
@@ -212,26 +212,26 @@ class TestWrite(_IntegrationTest):
   def test_create_and_overwrite_file(self):
     self.client.write('up', b'hello, world!')
     self.client.write('up', b'hello again, world!', overwrite=True)
-    eq_(self._read('up'), b'hello again, world!')
+    assert self._read('up') == b'hello again, world!'
 
   def test_as_context_manager(self):
     with self.client.write('up') as writer:
       writer.write(b'hello, ')
       writer.write(b'world!')
-    eq_(self._read('up'), b'hello, world!')
+    assert self._read('up') == b'hello, world!'
 
   def test_as_context_manager_with_encoding(self):
     with self.client.write('up', encoding='utf-8') as writer:
       writer.write(u'hello, ')
       writer.write(u'world!')
-    eq_(self._read('up'), b'hello, world!')
+    assert self._read('up') == b'hello, world!'
 
   def test_dump_json(self):
     from json import dump, loads
     data = {'one': 1, 'two': 2}
     with self.client.write('up', encoding='utf-8') as writer:
       dump(data, writer)
-    eq_(loads(self._read('up', encoding='utf-8')), data)
+    assert loads(self._read('up', encoding='utf-8')) == data
 
   def test_create_and_overwrite_directory(self):
     with pytest.raises(HdfsError):
@@ -265,7 +265,7 @@ class TestAppend(_IntegrationTest):
   def test_simple(self):
     self.client.write('ap', b'hello,')
     self.client.write('ap', b' world!', append=True)
-    eq_(self._read('ap'), b'hello, world!')
+    assert self._read('ap') == b'hello, world!'
 
   def test_missing_file(self):
     with pytest.raises(HdfsError):
@@ -287,7 +287,7 @@ class TestUpload(_IntegrationTest):
       with open(tpath, 'w') as writer:
         writer.write('hello, world!')
       self.client.upload('up', tpath)
-    eq_(self._read('up'), b'hello, world!')
+    assert self._read('up') == b'hello, world!'
 
   def test_upload_missing(self):
     with pytest.raises(HdfsError):
@@ -314,8 +314,8 @@ class TestUpload(_IntegrationTest):
         writer.write('world!')
       self.client._mkdirs('up')
       self.client.upload('up', npath)
-      eq_(self._read('up/hi/foo'), b'hello!')
-      eq_(self._read('up/hi/bar/baz'), b'world!')
+      assert self._read('up/hi/foo') == b'hello!'
+      assert self._read('up/hi/bar/baz') == b'world!'
     finally:
       rmtree(dpath)
 
@@ -328,8 +328,8 @@ class TestUpload(_IntegrationTest):
       with open(osp.join(dpath, 'bar', 'baz'), 'w') as writer:
         writer.write('world!')
       self.client.upload('up', dpath)
-      eq_(self._read('up/foo'), b'hello!')
-      eq_(self._read('up/bar/baz'), b'world!')
+      assert self._read('up/foo') == b'hello!'
+      assert self._read('up/bar/baz') == b'world!'
     finally:
       rmtree(dpath)
 
@@ -343,8 +343,8 @@ class TestUpload(_IntegrationTest):
         writer.write('world!')
       self._write('up', b'hi')
       self.client.upload('up', dpath, overwrite=True)
-      eq_(self._read('up/foo'), b'hello!')
-      eq_(self._read('up/bar/baz'), b'world!')
+      assert self._read('up/foo') == b'hello!'
+      assert self._read('up/bar/baz') == b'world!'
     finally:
       rmtree(dpath)
 
@@ -357,7 +357,7 @@ class TestUpload(_IntegrationTest):
       with open(tpath, 'w') as writer:
         writer.write('there')
       self.client.upload('up', tpath, overwrite=True)
-    eq_(self._read('up'), b'there')
+    assert self._read('up') == b'there'
 
   def test_upload_overwrite_error(self):
     with pytest.raises(HdfsError):
@@ -388,9 +388,9 @@ class TestUpload(_IntegrationTest):
       try:
         self.client.upload('foo', dpath)
       except RuntimeError:
-        ok_(not self._exists('foo'))
+        assert not self._exists('foo')
       else:
-        ok_(False) # This shouldn't happen.
+        assert False # This shouldn't happen.
     finally:
       rmtree(dpath)
       self.client.write = _write
@@ -417,9 +417,9 @@ class TestUpload(_IntegrationTest):
         self.client.upload('foo', dpath, cleanup=False)
       except RuntimeError:
         # The outer folder still exists.
-        ok_(self._exists('foo'))
+        assert self._exists('foo')
       else:
-        ok_(False) # This shouldn't happen.
+        assert False # This shouldn't happen.
     finally:
       rmtree(dpath)
       self.client.write = _write
@@ -446,12 +446,11 @@ class TestUpload(_IntegrationTest):
         n_threads=1, # Callback isn't thread-safe.
         progress=callback
       )
-      eq_(self._read('up/foo'), b'hello!')
-      eq_(self._read('up/bar/baz'), b'the world!')
-      eq_(
-        callback('', 0),
-        {path1: [4, 6, -1], path2: [4, 8, 10, -1], '': [0]}
-      )
+      assert self._read('up/foo') == b'hello!'
+      assert self._read('up/bar/baz') == b'the world!'
+      assert (
+        callback('', 0) ==
+        {path1: [4, 6, -1], path2: [4, 8, 10, -1], '': [0]})
     finally:
       rmtree(dpath)
 
@@ -460,21 +459,21 @@ class TestDelete(_IntegrationTest):
 
   def test_delete_file(self):
     self._write('foo', b'hello, world!')
-    ok_(self.client.delete('foo'))
-    ok_(not self._exists('foo'))
+    assert self.client.delete('foo')
+    assert not self._exists('foo')
 
   def test_delete_empty_directory(self):
     self.client._mkdirs('foo')
-    ok_(self.client.delete('foo'))
-    ok_(not self._exists('foo'))
+    assert self.client.delete('foo')
+    assert not self._exists('foo')
 
   def test_delete_missing_file(self):
-    ok_(not self.client.delete('foo'))
+    assert not self.client.delete('foo')
 
   def test_delete_non_empty_directory(self):
     self._write('de/foo', b'hello, world!')
-    ok_(self.client.delete('de', recursive=True))
-    ok_(not self._exists('de'))
+    assert self.client.delete('de', recursive=True)
+    assert not self._exists('de')
 
   def test_delete_non_empty_directory_without_recursive(self):
     with pytest.raises(HdfsError):
@@ -483,11 +482,11 @@ class TestDelete(_IntegrationTest):
 
   def test_trash_file(self):
     self._write('foo', b'hello, world!')
-    ok_(self.client.delete('foo', skip_trash=False))
-    eq_(self.client.status('foo', strict=False), None)
+    assert self.client.delete('foo', skip_trash=False)
+    assert self.client.status('foo', strict=False) == None
 
   def test_trash_missing_file(self):
-    ok_(not self.client.delete('foo', skip_trash=False))
+    assert not self.client.delete('foo', skip_trash=False)
 
   def test_trash_directory_non_recursive(self):
     with pytest.raises(HdfsError):
@@ -496,8 +495,8 @@ class TestDelete(_IntegrationTest):
 
   def test_trash_directory(self):
     self._write('bar/foo', b'hello, world!')
-    ok_(self.client.delete('bar', recursive=True, skip_trash=False))
-    eq_(self.client.status('bar', strict=False), None)
+    assert self.client.delete('bar', recursive=True, skip_trash=False)
+    assert self.client.status('bar', strict=False) == None
 
 
 class TestRead(_IntegrationTest):
@@ -523,7 +522,7 @@ class TestRead(_IntegrationTest):
   def test_read_file(self):
     self._write('foo', b'hello, world!')
     with self.client.read('foo') as reader:
-      eq_(reader.read(), b'hello, world!')
+      assert reader.read() == b'hello, world!'
 
   def test_read_directory(self):
     with pytest.raises(HdfsError):
@@ -539,17 +538,17 @@ class TestRead(_IntegrationTest):
   def test_read_file_from_offset(self):
     self._write('foo', b'hello, world!')
     with self.client.read('foo', offset=7) as reader:
-      eq_(reader.read(), b'world!')
+      assert reader.read() == b'world!'
 
   def test_read_file_from_offset_with_limit(self):
     self._write('foo', b'hello, world!')
     with self.client.read('foo', offset=7, length=5) as reader:
-      eq_(reader.read(), b'world')
+      assert reader.read() == b'world'
 
   def test_read_file_with_chunk_size(self):
     self._write('foo', b'hello, world!')
     with self.client.read('foo', chunk_size=5) as reader:
-      eq_(list(reader), [b'hello', b', wor', b'ld!'])
+      assert list(reader) == [b'hello', b', wor', b'ld!']
 
   def test_with_progress(self):
     def cb(path, nbytes, chunk_lengths=[]):
@@ -562,32 +561,32 @@ class TestRead(_IntegrationTest):
           for chunk in reader:
             writer.write(chunk)
       with open(tpath, 'rb') as reader:
-        eq_(reader.read(), b'hello, world!')
-      eq_(cb('', 0), [5, 10, 13, -1, 0])
+        assert reader.read() == b'hello, world!'
+      assert cb('', 0) == [5, 10, 13, -1, 0]
 
   def test_read_with_encoding(self):
     s = u'hello, world!'
     self._write('foo', s, encoding='utf-8')
     with self.client.read('foo', encoding='utf-8') as reader:
-      eq_(reader.read(), s)
+      assert reader.read() == s
 
   def test_read_with_chunk_size_and_encoding(self):
     s = u'hello, world!'
     self._write('foo', s, encoding='utf-8')
     with self.client.read('foo', chunk_size=5, encoding='utf-8') as reader:
-      eq_(list(reader), [u'hello', u', wor', u'ld!'])
+      assert list(reader) == [u'hello', u', wor', u'ld!']
 
   def test_read_json(self):
     from json import dumps, load
     data = {'one': 1, 'two': 2}
     self._write('foo', data=dumps(data), encoding='utf-8')
     with self.client.read('foo', encoding='utf-8') as reader:
-      eq_(load(reader), data)
+      assert load(reader) == data
 
   def test_read_with_delimiter(self):
     self._write('foo', u'hi\nworld!\n', encoding='utf-8')
     with self.client.read('foo', delimiter='\n', encoding='utf-8') as reader:
-      eq_(list(reader), [u'hi', u'world!', u''])
+      assert list(reader) == [u'hi', u'world!', u'']
 
 
 class TestRename(_IntegrationTest):
@@ -595,7 +594,7 @@ class TestRename(_IntegrationTest):
   def test_rename_file(self):
     self._write('foo', b'hello, world!')
     self.client.rename('foo', 'bar')
-    eq_(self._read('bar'), b'hello, world!')
+    assert self._read('bar') == b'hello, world!'
 
   def test_rename_missing_file(self):
     with pytest.raises(HdfsError):
@@ -611,19 +610,19 @@ class TestRename(_IntegrationTest):
     self._write('foo', b'hello, world!')
     self.client._mkdirs('bar')
     self.client.rename('foo', 'bar')
-    eq_(self._read('bar/foo'), b'hello, world!')
+    assert self._read('bar/foo') == b'hello, world!'
 
   def test_rename_file_into_existing_directory(self):
     self._write('foo', b'hello, world!')
     self.client._mkdirs('bar')
     self.client.rename('foo', 'bar/baz')
-    eq_(self._read('bar/baz'), b'hello, world!')
+    assert self._read('bar/baz') == b'hello, world!'
 
   def test_rename_file_with_special_characters(self):
     path = 'fo&oa ?a=1'
     self._write('foo', b'hello, world!')
     self.client.rename('foo', path)
-    eq_(self._read(path), b'hello, world!')
+    assert self._read(path) == b'hello, world!'
 
 
 class TestDownload(_IntegrationTest):
@@ -639,7 +638,7 @@ class TestDownload(_IntegrationTest):
     with temppath() as tpath:
       fpath = self.client.download('dl', tpath)
       with open(fpath) as reader:
-        eq_(reader.read(), 'hello')
+        assert reader.read() == 'hello'
 
   def test_nonpartitioned_file(self):
     partname = 'part-r-00000'
@@ -647,7 +646,7 @@ class TestDownload(_IntegrationTest):
     with temppath() as tpath:
       fname = self.client.download('dl/' + partname, tpath)
       with open(fname) as reader:
-        eq_(reader.read(), 'world')
+        assert reader.read() == 'world'
 
   def test_singly_partitioned_file(self):
     partname = 'part-r-00000'
@@ -656,7 +655,7 @@ class TestDownload(_IntegrationTest):
       os.mkdir(tpath)
       fname = self.client.download('dl', tpath)
       with open(osp.join(fname, partname)) as reader:
-        eq_(reader.read(), 'world')
+        assert reader.read() == 'world'
 
   def _download_partitioned_file(self, n_threads):
     parts = {
@@ -669,10 +668,10 @@ class TestDownload(_IntegrationTest):
     with temppath() as tpath:
       self.client.download('dl', tpath, n_threads=-1)
       local_parts = os.listdir(tpath)
-      eq_(set(local_parts), set(parts)) # We have all the parts.
+      assert set(local_parts) == set(parts) # We have all the parts.
       for part in local_parts:
         with open(osp.join(tpath, part), mode='rb') as reader:
-          eq_(reader.read(), parts[part]) # Their content is correct.
+          assert reader.read() == parts[part] # Their content is correct.
 
   def test_partitioned_file_max_threads(self):
     self._download_partitioned_file(0)
@@ -690,7 +689,7 @@ class TestDownload(_IntegrationTest):
       self.client.write('dl', b'there', overwrite=True)
       fname = self.client.download('dl', tpath, overwrite=True)
       with open(fname) as reader:
-        eq_(reader.read(), 'there')
+        assert reader.read() == 'there'
 
   def test_download_file_to_existing_file(self):
     with pytest.raises(HdfsError):
@@ -707,7 +706,7 @@ class TestDownload(_IntegrationTest):
         writer.write('hi')
       self.client.download('dl', tpath, overwrite=True)
       with open(tpath) as reader:
-        eq_(reader.read(), 'hello')
+        assert reader.read() == 'hello'
 
   def test_download_file_to_existing_folder(self):
     self._write('dl', b'hello')
@@ -715,7 +714,7 @@ class TestDownload(_IntegrationTest):
       os.mkdir(tpath)
       self.client.download('dl', tpath)
       with open(osp.join(tpath, 'dl')) as reader:
-        eq_(reader.read(), 'hello')
+        assert reader.read() == 'hello'
 
   def test_download_file_to_existing_folder_with_matching_file(self):
     with pytest.raises(HdfsError):
@@ -734,7 +733,7 @@ class TestDownload(_IntegrationTest):
         writer.write('hey')
       self.client.download('dl', tpath, overwrite=True)
       with open(osp.join(tpath, 'dl')) as reader:
-        eq_(reader.read(), 'hello')
+        assert reader.read() == 'hello'
 
   def test_download_folder_to_existing_folder(self):
     self._write('foo/dl', b'hello')
@@ -743,9 +742,9 @@ class TestDownload(_IntegrationTest):
       os.mkdir(tpath)
       self.client.download('foo', tpath)
       with open(osp.join(tpath, 'foo', 'dl')) as reader:
-        eq_(reader.read(), 'hello')
+        assert reader.read() == 'hello'
       with open(osp.join(tpath, 'foo', 'bar', 'dl')) as reader:
-        eq_(reader.read(), 'there')
+        assert reader.read() == 'there'
 
   def test_download_folder_to_existing_folder_parallel(self):
     self._write('foo/dl', b'hello')
@@ -754,9 +753,9 @@ class TestDownload(_IntegrationTest):
       os.mkdir(tpath)
       self.client.download('foo', tpath, n_threads=0)
       with open(osp.join(tpath, 'foo', 'dl')) as reader:
-        eq_(reader.read(), 'hello')
+        assert reader.read() == 'hello'
       with open(osp.join(tpath, 'foo', 'bar', 'dl')) as reader:
-        eq_(reader.read(), 'there')
+        assert reader.read() == 'there'
 
   def test_download_folder_to_missing_folder(self):
     self._write('foo/dl', b'hello')
@@ -764,9 +763,9 @@ class TestDownload(_IntegrationTest):
     with temppath() as tpath:
       self.client.download('foo', tpath)
       with open(osp.join(tpath, 'dl')) as reader:
-        eq_(reader.read(), 'hello')
+        assert reader.read() == 'hello'
       with open(osp.join(tpath, 'bar', 'dl')) as reader:
-        eq_(reader.read(), 'there')
+        assert reader.read() == 'there'
 
   def test_download_cleanup(self):
     self._write('foo/dl', b'hello')
@@ -783,9 +782,9 @@ class TestDownload(_IntegrationTest):
         self.client.read = read
         self.client.download('foo', tpath)
       except RuntimeError:
-        ok_(not osp.exists(tpath))
+        assert not osp.exists(tpath)
       else:
-        ok_(False) # This shouldn't happen.
+        assert False # This shouldn't happen.
       finally:
         self.client.read = _read
 
@@ -800,14 +799,14 @@ class TestDownload(_IntegrationTest):
     with temppath() as tpath:
       self.client.download('foo', tpath)
       with open(osp.join(tpath, 'foo bar.txt')) as reader:
-        eq_(reader.read(), 'hello')
+        assert reader.read() == 'hello'
 
   def test_download_file_whitespace(self):
     self._write('foo/foo bar%.txt', b'hello')
     with temppath() as tpath:
       self.client.download('foo/foo bar%.txt', tpath)
       with open(tpath) as reader:
-        eq_(reader.read(), 'hello')
+        assert reader.read() == 'hello'
 
 
 class TestStatus(_IntegrationTest):
@@ -815,21 +814,21 @@ class TestStatus(_IntegrationTest):
   def test_directory(self):
     self.client._mkdirs('foo')
     status = self.client.status('foo')
-    eq_(status['type'], 'DIRECTORY')
-    eq_(status['length'], 0)
+    assert status['type'] == 'DIRECTORY'
+    assert status['length'] == 0
 
   def test_file(self):
     self._write('foo', b'hello, world!')
     status = self.client.status('foo')
-    eq_(status['type'], 'FILE')
-    eq_(status['length'], 13)
+    assert status['type'] == 'FILE'
+    assert status['length'] == 13
 
   def test_missing(self):
     with pytest.raises(HdfsError):
       self.client.status('foo')
 
   def test_missing_non_strict(self):
-    ok_(self.client.status('foo', strict=False) is None)
+    assert self.client.status('foo', strict=False) is None
 
 
 class TestSetOwner(_IntegrationTest):
@@ -854,7 +853,7 @@ class TestSetOwner(_IntegrationTest):
     self.client.set_owner('foo', 'oldowner')
     self.client.set_owner('foo', new_owner)
     status = self.client.status('foo')
-    eq_(status['owner'], new_owner)
+    assert status['owner'] == new_owner
 
   def test_file_owner(self):
     new_owner = 'newowner'
@@ -862,7 +861,7 @@ class TestSetOwner(_IntegrationTest):
     self.client.set_owner('foo', 'oldowner')
     self.client.set_owner('foo', new_owner)
     status = self.client.status('foo')
-    eq_(status['owner'], new_owner)
+    assert status['owner'] == new_owner
 
   def test_directory_for_group(self):
     new_group = 'newgroup'
@@ -870,7 +869,7 @@ class TestSetOwner(_IntegrationTest):
     self.client.set_owner('foo', group='oldgroup')
     self.client.set_owner('foo', group=new_group)
     status = self.client.status('foo')
-    eq_(status['group'], new_group)
+    assert status['group'] == new_group
 
   def test_file_for_group(self):
     new_group = 'newgroup'
@@ -878,7 +877,7 @@ class TestSetOwner(_IntegrationTest):
     self.client.set_owner('foo', group='oldgroup')
     self.client.set_owner('foo', group=new_group)
     status = self.client.status('foo')
-    eq_(status['group'], new_group)
+    assert status['group'] == new_group
 
   def test_missing_for_group(self):
     with pytest.raises(HdfsError):
@@ -892,14 +891,14 @@ class TestSetPermission(_IntegrationTest):
     self.client._mkdirs('foo', permission='444')
     self.client.set_permission('foo', new_permission)
     status = self.client.status('foo')
-    eq_(status['permission'], new_permission)
+    assert status['permission'] == new_permission
 
   def test_file(self):
     new_permission = '755'
     self.client.write('foo', b'hello, world!', permission='444')
     self.client.set_permission('foo', new_permission)
     status = self.client.status('foo')
-    eq_(status['permission'], new_permission)
+    assert status['permission'] == new_permission
 
   def test_missing(self):
     with pytest.raises(HdfsError):
@@ -911,23 +910,23 @@ class TestContent(_IntegrationTest):
   def test_directory(self):
     self._write('foo', b'hello, world!')
     content = self.client.content('')
-    eq_(content['directoryCount'], 1)
-    eq_(content['fileCount'], 1)
-    eq_(content['length'], 13)
+    assert content['directoryCount'] == 1
+    assert content['fileCount'] == 1
+    assert content['length'] == 13
 
   def test_file(self):
     self._write('foo', b'hello, world!')
     content = self.client.content('foo')
-    eq_(content['directoryCount'], 0)
-    eq_(content['fileCount'], 1)
-    eq_(content['length'], 13)
+    assert content['directoryCount'] == 0
+    assert content['fileCount'] == 1
+    assert content['length'] == 13
 
   def test_missing(self):
     with pytest.raises(HdfsError):
       self.client.content('foo')
 
   def test_missing_non_strict(self):
-    ok_(self.client.content('foo', strict=False) is None)
+    assert self.client.content('foo', strict=False) is None
 
 
 class TestAcl(_IntegrationTest):
@@ -935,53 +934,53 @@ class TestAcl(_IntegrationTest):
   def test_directory(self):
     self._write('foo', b'hello, world!')
     content = self.client.acl_status('')
-    ok_(len(content) > 1)
-    ok_('entries' in content)
-    ok_('group' in content)
-    ok_('owner' in content)
+    assert len(content) > 1
+    assert 'entries' in content
+    assert 'group' in content
+    assert 'owner' in content
 
   def test_set_acl(self):
     self.client.write('foo', 'hello, world!')
     self.client.set_acl('foo', 'user::rwx,user:foouser:rwx,group::r--,other::---')
     content = self.client.acl_status('foo')
-    ok_(any('user:foouser:rwx' in s for s in content['entries']))
-    ok_(len(content) > 1)
-    ok_(content['entries'] is not None)
+    assert any('user:foouser:rwx' in s for s in content['entries'])
+    assert len(content) > 1
+    assert content['entries'] is not None
 
   def test_modify_acl(self):
     self.client.write('foo', 'hello, world!')
     self.client.set_acl('foo', 'user::rwx,user:foouser:rwx,group::r--,other::---')
     self.client.set_acl('foo', 'user:foouser:rw-', clear=False)
     content = self.client.acl_status('foo')
-    ok_(any('user:foouser:rw-' in s for s in content['entries']))
+    assert any('user:foouser:rw-' in s for s in content['entries'])
 
   def test_missing(self):
     with pytest.raises(HdfsError):
       self.client.acl_status('foo')
 
   def test_missing_non_strict(self):
-    ok_(self.client.acl_status('foo', strict=False) is None)
+    assert self.client.acl_status('foo', strict=False) is None
 
   def test_remove_acl_entries(self):
     self.client.write('foo', 'hello, world!')
     self.client.set_acl('foo', 'user:baruser:rwx,user:foouser:rw-', clear=False)
     self.client.remove_acl_entries('foo', 'user:foouser:')
     content = self.client.acl_status('foo')
-    ok_(not any('user:foouser:rw-' in s for s in content['entries']))
-    ok_(any('user:baruser:rwx' in s for s in content['entries']))
+    assert not any('user:foouser:rw-' in s for s in content['entries'])
+    assert any('user:baruser:rwx' in s for s in content['entries'])
 
   def test_remove_default_acl(self):
     self.client.write('foo', 'hello, world!')
     self.client.set_acl('foo', 'user:foouser:rwx', clear=False)
     self.client.remove_default_acl('foo')
     content = self.client.acl_status('foo')
-    ok_(not any('user::rwx' in s for s in content['entries']))
+    assert not any('user::rwx' in s for s in content['entries'])
 
   def test_remove_acl(self):
     self.client.write('foo', 'hello, world!')
     self.client.remove_acl('foo')
     content = self.client.acl_status('foo')
-    eq_(content.get('entries'), [])
+    assert content.get('entries') == []
 
 
 class TestList(_IntegrationTest):
@@ -997,19 +996,19 @@ class TestList(_IntegrationTest):
 
   def test_empty_dir(self):
     self.client._mkdirs('foo')
-    eq_(self.client.list('foo'), [])
+    assert self.client.list('foo') == []
 
   def test_dir(self):
     self.client.write('foo/bar', 'hello, world!')
-    eq_(self.client.list('foo'), ['bar'])
+    assert self.client.list('foo') == ['bar']
 
   def test_dir_with_status(self):
     self.client.write('foo/bar', 'hello, world!')
     statuses = self.client.list('foo', status=True)
-    eq_(len(statuses), 1)
+    assert len(statuses) == 1
     status = self.client.status('foo/bar')
     status['pathSuffix'] = 'bar'
-    eq_(statuses[0], ('bar', status))
+    assert statuses[0] == ('bar', status)
 
 
 class TestWalk(_IntegrationTest):
@@ -1020,42 +1019,41 @@ class TestWalk(_IntegrationTest):
 
   def test_file(self):
     self.client.write('foo', 'hello, world!')
-    ok_(not list(self.client.walk('foo')))
+    assert not list(self.client.walk('foo'))
 
   def test_folder(self):
     self.client.write('hello', 'hello, world!')
     self.client.write('foo/hey', 'hey, world!')
     infos = list(self.client.walk(''))
-    eq_(len(infos), 2)
-    eq_(infos[0], (psp.join(self.client.root), ['foo'], ['hello']))
-    eq_(infos[1], (psp.join(self.client.root, 'foo'), [], ['hey']))
+    assert len(infos) == 2
+    assert infos[0] == (psp.join(self.client.root), ['foo'], ['hello'])
+    assert infos[1] == (psp.join(self.client.root, 'foo'), [], ['hey'])
 
   def test_folder_with_depth(self):
     self.client.write('foo/bar', 'hello, world!')
     infos = list(self.client.walk('', depth=1))
-    eq_(len(infos), 1)
-    eq_(infos[0], (self.client.root, ['foo'], []))
+    assert len(infos) == 1
+    assert infos[0] == (self.client.root, ['foo'], [])
 
   def test_folder_with_status(self):
     self.client.write('foo', 'hello, world!')
     infos = list(self.client.walk('', status=True))
     status = self.client.status('foo')
     status['pathSuffix'] = 'foo'
-    eq_(len(infos), 1)
-    eq_(
-      infos[0],
+    assert len(infos) == 1
+    assert (
+      infos[0] ==
       (
         (self.client.root, self.client.status('')),
         [],
         [('foo', status)]
-      )
-    )
+      ))
 
   def test_skip_missing_folder(self):
     self.client.write('file', 'one')
     self.client.write('folder/hey', 'two')
     for info in self.client.walk('', ignore_missing=True):
-      eq_(info, (psp.join(self.client.root), ['folder'], ['file']))
+      assert info == (psp.join(self.client.root), ['folder'], ['file'])
       self.client.delete('folder', recursive=True)
 
   def test_status_and_allow_dir_changes(self):
@@ -1069,7 +1067,7 @@ class TestWalk(_IntegrationTest):
     info = next(infos)
     info[1][:] = ['bar']
     info = next(infos)
-    eq_(info, (psp.join(self.client.root, 'bar'), [], ['file2']))
+    assert info == (psp.join(self.client.root, 'bar'), [], ['file2'])
 
   def test_allow_dir_changes_insert(self):
     self.client.write('foo/file1', 'one')
@@ -1078,7 +1076,7 @@ class TestWalk(_IntegrationTest):
     self.client.write('bar/file2', 'two')
     info[1][:] = ['bar'] # Insert new directory.
     info = next(infos)
-    eq_(info, (psp.join(self.client.root, 'bar'), [], ['file2']))
+    assert info == (psp.join(self.client.root, 'bar'), [], ['file2'])
 
 
 class TestLatestExpansion(_IntegrationTest):
@@ -1086,26 +1084,26 @@ class TestLatestExpansion(_IntegrationTest):
   def test_resolve_simple(self):
     self.client.write('bar', 'hello, world!')
     self.client.write('foo', 'hello again, world!')
-    eq_(self.client.resolve('#LATEST'), osp.join(self.client.root, 'foo'))
+    assert self.client.resolve('#LATEST') == osp.join(self.client.root, 'foo')
 
   def test_resolve_nested(self):
     self.client.write('baz/bar', 'hello, world!')
     self.client.write('bar/bar', 'hello there, world!')
     self.client.write('bar/foo', 'hello again, world!')
     latest = self.client.resolve('#LATEST/#LATEST')
-    eq_(latest, osp.join(self.client.root, 'bar', 'foo'))
+    assert latest == osp.join(self.client.root, 'bar', 'foo')
 
   def test_resolve_multiple(self):
     self.client.write('bar/bar', 'hello, world!')
     self.client.write('bar/foo', 'hello again, world!')
     latest = self.client.resolve('#LATEST/#LATEST')
-    eq_(latest, osp.join(self.client.root, 'bar', 'foo'))
+    assert latest == osp.join(self.client.root, 'bar', 'foo')
 
   def test_resolve_multiple_shortcut(self):
     self.client.write('bar/bar', 'hello, world!')
     self.client.write('bar/foo', 'hello again, world!')
     latest = self.client.resolve('#LATEST{2}')
-    eq_(latest, osp.join(self.client.root, 'bar', 'foo'))
+    assert latest == osp.join(self.client.root, 'bar', 'foo')
 
   @pytest.mark.skip(reason="HttpFS is inconsistent here.")
   def test_resolve_file(self):
@@ -1143,20 +1141,20 @@ class TestParts(_IntegrationTest):
   def test_folder_with_single_part(self):
     fname = 'part-m-00000.avro'
     self.client.write(psp.join('foo', fname), 'first')
-    eq_(self.client.parts('foo'), [fname])
+    assert self.client.parts('foo') == [fname]
 
   def test_folder_with_multiple_parts(self):
     fnames = ['part-m-00000.avro', 'part-m-00001.avro']
     self.client.write(psp.join('foo', fnames[0]), 'first')
     self.client.write(psp.join('foo', fnames[1]), 'second')
-    eq_(self.client.parts('foo'), fnames)
+    assert self.client.parts('foo') == fnames
 
   def test_folder_with_multiple_parts_and_others(self):
     fnames = ['part-m-00000.avro', 'part-m-00001.avro']
     self.client.write(psp.join('foo', '.header'), 'metadata')
     self.client.write(psp.join('foo', fnames[0]), 'first')
     self.client.write(psp.join('foo', fnames[1]), 'second')
-    eq_(self.client.parts('foo'), fnames)
+    assert self.client.parts('foo') == fnames
 
   def test_with_selection(self):
     fnames = ['part-m-00000.avro', 'part-m-00001.avro']
@@ -1164,15 +1162,15 @@ class TestParts(_IntegrationTest):
     self.client.write(psp.join('foo', fnames[0]), 'first')
     self.client.write(psp.join('foo', fnames[1]), 'second')
     parts = self.client.parts('foo', parts=1)
-    eq_(len(parts), 1)
-    ok_(parts[0] in fnames)
+    assert len(parts) == 1
+    assert parts[0] in fnames
 
   def test_with_selection(self):
     fnames = ['part-m-00000.avro', 'part-m-00001.avro']
     self.client.write(psp.join('foo', '.header'), 'metadata')
     self.client.write(psp.join('foo', fnames[0]), 'first')
     self.client.write(psp.join('foo', fnames[1]), 'second')
-    eq_(self.client.parts('foo', parts=[1]), fnames[1:])
+    assert self.client.parts('foo', parts=[1]) == fnames[1:]
 
   def test_with_status(self):
     fname = 'part-m-00000.avro'
@@ -1180,22 +1178,22 @@ class TestParts(_IntegrationTest):
     self.client.write(fpath, 'first')
     status = self.client.status(fpath)
     status['pathSuffix'] = fname
-    eq_(self.client.parts('foo', status=True), [(fname, status)])
+    assert self.client.parts('foo', status=True) == [(fname, status)]
 
 
 class TestMakeDirs(_IntegrationTest):
 
   def test_simple(self):
     self.client.makedirs('foo')
-    eq_(self.client.status('foo')['type'], 'DIRECTORY')
+    assert self.client.status('foo')['type'] == 'DIRECTORY'
 
   def test_nested(self):
     self.client.makedirs('foo/bar')
-    eq_(self.client.status('foo/bar')['type'], 'DIRECTORY')
+    assert self.client.status('foo/bar')['type'] == 'DIRECTORY'
 
   def test_with_permission(self):
     self.client.makedirs('foo', permission='733')
-    eq_(self.client.status('foo')['permission'], '733')
+    assert self.client.status('foo')['permission'] == '733'
 
   def test_overwrite_file(self):
     with pytest.raises(HdfsError):
@@ -1205,8 +1203,8 @@ class TestMakeDirs(_IntegrationTest):
   def test_overwrite_directory_with_permission(self):
     self.client.makedirs('foo', permission='733')
     self.client.makedirs('foo/bar', permission='722')
-    eq_(self.client.status('foo')['permission'], '733')
-    eq_(self.client.status('foo/bar')['permission'], '722')
+    assert self.client.status('foo')['permission'] == '733'
+    assert self.client.status('foo/bar')['permission'] == '722'
 
 
 class TestSetTimes(_IntegrationTest):
@@ -1229,24 +1227,24 @@ class TestSetTimes(_IntegrationTest):
   def test_file(self):
     self.client.write('foo', 'hello')
     self.client.set_times('foo', access_time=1234)
-    eq_(self.client.status('foo')['accessTime'], 1234)
+    assert self.client.status('foo')['accessTime'] == 1234
     self.client.set_times('foo', modification_time=12345)
-    eq_(self.client.status('foo')['modificationTime'], 12345)
+    assert self.client.status('foo')['modificationTime'] == 12345
     self.client.set_times('foo', access_time=1, modification_time=2)
     status = self.client.status('foo')
-    eq_(status['accessTime'], 1)
-    eq_(status['modificationTime'], 2)
+    assert status['accessTime'] == 1
+    assert status['modificationTime'] == 2
 
   def test_folder(self):
     self.client.write('foo/bar', 'hello')
     self.client.set_times('foo', access_time=1234)
-    eq_(self.client.status('foo')['accessTime'], 1234)
+    assert self.client.status('foo')['accessTime'] == 1234
     self.client.set_times('foo', modification_time=12345)
-    eq_(self.client.status('foo')['modificationTime'], 12345)
+    assert self.client.status('foo')['modificationTime'] == 12345
     self.client.set_times('foo', access_time=1, modification_time=2)
     status = self.client.status('foo')
-    eq_(status['accessTime'], 1)
-    eq_(status['modificationTime'], 2)
+    assert status['accessTime'] == 1
+    assert status['modificationTime'] == 2
 
 
 class TestChecksum(_IntegrationTest):
@@ -1263,7 +1261,7 @@ class TestChecksum(_IntegrationTest):
   def test_file(self):
     self.client.write('foo', 'hello')
     checksum = self.client.checksum('foo')
-    eq_({'algorithm', 'bytes', 'length'}, set(checksum))
+    assert {'algorithm', 'bytes', 'length'} == set(checksum)
 
 
 class TestSetReplication(_IntegrationTest):
@@ -1286,19 +1284,19 @@ class TestSetReplication(_IntegrationTest):
     self.client.write('foo', 'hello')
     replication = self.client.status('foo')['replication'] + 1
     self.client.set_replication('foo', replication)
-    eq_(self.client.status('foo')['replication'], replication)
+    assert self.client.status('foo')['replication'] == replication
 
 
 class TestTokenClient(object):
 
   def test_without_session(self):
     client = TokenClient('url', '123')
-    eq_(client._session.params['delegation'], '123')
+    assert client._session.params['delegation'] == '123'
 
   def test_with_session(self):
     session = rq.Session()
     client = TokenClient('url', '123', session=session)
-    eq_(session.params['delegation'], '123')
+    assert session.params['delegation'] == '123'
 
 
 class TestSnapshot(_IntegrationTest):
@@ -1368,7 +1366,7 @@ class TestSnapshot(_IntegrationTest):
     self.client.allow_snapshot('foo')
     try:
       snapshot_path = self.client.create_snapshot('foo', 'mysnap')
-      assert_regex(snapshot_path, r'/foo/\.snapshot/mysnap$')
+      assert re.search(r'/foo/\.snapshot/mysnap$',snapshot_path)
     finally:
       # Cleanup, as it breaks other tests otherwise: the dir cannot be
       # removed with an active snapshots.

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -7,7 +7,6 @@ from collections import defaultdict
 from hdfs.client import *
 from hdfs.util import HdfsError, temppath
 from util import _IntegrationTest
-from nose.tools import eq_, ok_, assert_regex
 from requests.exceptions import ConnectTimeout, ReadTimeout
 from shutil import rmtree
 from six import b

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -27,7 +27,7 @@ class TestConfig(object):
         os.environ['HDFSCLI_CONFIG'] = tpath
         with open(tpath, 'w') as writer:
           writer.write('[foo]\nbar=hello')
-        eq_(Config().get('foo', 'bar'), 'hello')
+        assert Config().get('foo', 'bar') == 'hello'
     finally:
       if path:
         os['HDFSCLI_CONFIG'] = path
@@ -52,7 +52,7 @@ class TestConfig(object):
         config.set(config.global_section, 'autoload.paths', module_path)
         config._autoload()
         client = Client.from_options({'url': ''}, 'PathClient')
-        eq_(client.one, 1)
+        assert client.one == 1
 
   def test_autoload_missing_path(self):
     with pytest.raises(SystemExit):
@@ -76,7 +76,7 @@ class TestConfig(object):
           config.set(config.global_section, 'autoload.modules', 'mclient')
           config._autoload()
           client = Client.from_options({'url': ''}, 'ModuleClient')
-          eq_(client.one, 1)
+          assert client.one == 1
       finally:
         sys.path.remove(module_dpath)
 
@@ -97,10 +97,10 @@ class TestConfig(object):
       config.set(section, 'url', 'http://host:port')
       config.set(section, 'timeout', '1')
       save_config(config)
-      eq_(Config(path=tpath).get_client('dev')._timeout, 1)
+      assert Config(path=tpath).get_client('dev')._timeout == 1
       config.set(section, 'timeout', '1,2')
       save_config(config)
-      eq_(Config(path=tpath).get_client('dev')._timeout, (1,2))
+      assert Config(path=tpath).get_client('dev')._timeout == (1,2)
 
   def test_create_client_with_missing_alias(self):
     with pytest.raises(HdfsError):
@@ -127,7 +127,7 @@ class TestConfig(object):
     with temppath() as tpath:
       config = Config(tpath)
       handler = config.get_log_handler('cmd')
-      ok_(isinstance(handler, TimedRotatingFileHandler))
+      assert isinstance(handler, TimedRotatingFileHandler)
 
   def test_disable_file_logging(self):
     with temppath() as tpath:
@@ -137,4 +137,4 @@ class TestConfig(object):
       save_config(config)
       config = Config(tpath)
       handler = config.get_log_handler('cmd')
-      ok_(not isinstance(handler, TimedRotatingFileHandler))
+      assert not isinstance(handler, TimedRotatingFileHandler)

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -7,18 +7,19 @@ from hdfs.client import Client
 from hdfs.config import Config
 from hdfs.util import HdfsError, temppath
 from logging.handlers import TimedRotatingFileHandler
-from nose.tools import eq_, ok_, nottest, raises
+from nose.tools import eq_, ok_
 from string import Template
 from util import save_config
 import logging as lg
 import os
 import os.path as osp
+import pytest
 import sys
 
 
 class TestConfig(object):
 
-  @nottest # TODO: Find cross-platform way to reset the environment variable.
+  @pytest.mark.skip(reason="TODO: Find cross-platform way to reset the environment variable.")
   def test_config_path(self):
     path = os.getenv('HDFSCLI_CONFIG')
     try:
@@ -53,14 +54,14 @@ class TestConfig(object):
         client = Client.from_options({'url': ''}, 'PathClient')
         eq_(client.one, 1)
 
-  @raises(SystemExit)
   def test_autoload_missing_path(self):
-    with temppath() as module_path:
-      with temppath() as config_path:
-        config = Config(config_path)
-        config.add_section(config.global_section)
-        config.set(config.global_section, 'autoload.paths', module_path)
-        config._autoload()
+    with pytest.raises(SystemExit):
+      with temppath() as module_path:
+        with temppath() as config_path:
+          config = Config(config_path)
+          config.add_section(config.global_section)
+          config.set(config.global_section, 'autoload.paths', module_path)
+          config._autoload()
 
   def test_autoload_client_from_module(self):
     with temppath() as module_dpath:
@@ -101,15 +102,15 @@ class TestConfig(object):
       save_config(config)
       eq_(Config(path=tpath).get_client('dev')._timeout, (1,2))
 
-  @raises(HdfsError)
   def test_create_client_with_missing_alias(self):
-    with temppath() as tpath:
-      Config(tpath).get_client('dev')
+    with pytest.raises(HdfsError):
+      with temppath() as tpath:
+        Config(tpath).get_client('dev')
 
-  @raises(HdfsError)
   def test_create_client_with_no_alias_without_default(self):
-    with temppath() as tpath:
-      Config(tpath).get_client()
+    with pytest.raises(HdfsError):
+      with temppath() as tpath:
+        Config(tpath).get_client()
 
   def test_create_client_with_default_alias(self):
     with temppath() as tpath:

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -7,7 +7,6 @@ from hdfs.client import Client
 from hdfs.config import Config
 from hdfs.util import HdfsError, temppath
 from logging.handlers import TimedRotatingFileHandler
-from nose.tools import eq_, ok_
 from string import Template
 from util import save_config
 import logging as lg

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -8,7 +8,7 @@ from hdfs.config import Config
 from hdfs.util import HdfsError, temppath
 from logging.handlers import TimedRotatingFileHandler
 from string import Template
-from util import save_config
+from test.util import save_config
 import logging as lg
 import os
 import os.path as osp

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -5,11 +5,11 @@
 
 from hdfs import Config
 from imp import load_source
-from nose.plugins.skip import SkipTest
 from six import add_metaclass
 from util import _IntegrationTest
 import os
 import os.path as osp
+import pytest
 
 
 class _ExamplesType(type):
@@ -29,7 +29,7 @@ class _ExamplesType(type):
           load_source(module, fpath)
         except ImportError:
           # Unmet dependency.
-          raise SkipTest
+          pytest.skip()
 
       test.__name__ = 'test_{}'.format(module)
       test.__doc__ = 'Test for example {}.'.format(fpath)

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -6,7 +6,7 @@
 from hdfs import Config
 from imp import load_source
 from six import add_metaclass
-from util import _IntegrationTest
+from test.util import _IntegrationTest
 import os
 import os.path as osp
 import pytest

--- a/test/test_ext_avro.py
+++ b/test/test_ext_avro.py
@@ -5,7 +5,7 @@
 
 from hdfs.util import HdfsError, temppath
 from json import dumps, load, loads
-from util import _IntegrationTest
+from test.util import _IntegrationTest
 import os
 import os.path as osp
 import pytest

--- a/test/test_ext_avro.py
+++ b/test/test_ext_avro.py
@@ -22,7 +22,7 @@ else:
 
 class TestSeekableReader(object):
 
-  def setup(self):
+  def setup_method(self):
     if SKIP:
       pytest.skip()
 
@@ -52,7 +52,7 @@ class TestSeekableReader(object):
 
 class TestInferSchema(object):
 
-  def setup(self):
+  def setup_method(self):
     if SKIP:
       pytest.skip()
 

--- a/test/test_ext_avro.py
+++ b/test/test_ext_avro.py
@@ -34,9 +34,9 @@ class TestSeekableReader(object):
         writer.write('abcd')
       with open(tpath) as reader:
         sreader = _SeekableReader(reader)
-        eq_(sreader.read(3), 'abc')
-        eq_(sreader.read(2), 'd')
-        ok_(not sreader.read(1))
+        assert sreader.read(3) == 'abc'
+        assert sreader.read(2) == 'd'
+        assert not sreader.read(1)
 
   def test_buffered_read(self):
     with temppath() as tpath:
@@ -44,12 +44,12 @@ class TestSeekableReader(object):
         writer.write('abcdefghi')
       with open(tpath) as reader:
         sreader = _SeekableReader(reader, 3)
-        eq_(sreader.read(1), 'a')
-        eq_(sreader.read(3), 'bcd')
+        assert sreader.read(1) == 'a'
+        assert sreader.read(3) == 'bcd'
         sreader.seek(-3, os.SEEK_CUR)
-        eq_(sreader.read(2), 'bc')
-        eq_(sreader.read(6), 'defghi')
-        ok_(not sreader.read(1))
+        assert sreader.read(2) == 'bc'
+        assert sreader.read(6) == 'defghi'
+        assert not sreader.read(1)
 
 
 class TestInferSchema(object):
@@ -59,8 +59,8 @@ class TestInferSchema(object):
       raise SkipTest
 
   def test_array(self):
-    eq_(
-      _SchemaInferrer().infer({'foo': 1, 'bar': ['hello']}),
+    assert (
+      _SchemaInferrer().infer({'foo': 1, 'bar': ['hello']}) ==
       {
         'type': 'record',
         'name': '__Record1',
@@ -68,12 +68,11 @@ class TestInferSchema(object):
           {'type': {'type': 'array', 'items': 'string'}, 'name': 'bar'},
           {'type': 'int', 'name': 'foo'},
         ]
-      }
-    )
+      })
 
   def test_flat_record(self):
-    eq_(
-      _SchemaInferrer().infer({'foo': 1, 'bar': 'hello'}),
+    assert (
+      _SchemaInferrer().infer({'foo': 1, 'bar': 'hello'}) ==
       {
         'type': 'record',
         'name': '__Record1',
@@ -81,12 +80,11 @@ class TestInferSchema(object):
           {'type': 'string', 'name': 'bar'},
           {'type': 'int', 'name': 'foo'},
         ]
-      }
-    )
+      })
 
   def test_nested_record(self):
-    eq_(
-      _SchemaInferrer().infer({'foo': {'bax': 2}, 'bar': {'baz': 3}}),
+    assert (
+      _SchemaInferrer().infer({'foo': {'bax': 2}, 'bar': {'baz': 3}}) ==
       {
         'type': 'record',
         'name': '__Record1',
@@ -108,8 +106,7 @@ class TestInferSchema(object):
             'name': 'foo',
           },
         ]
-      }
-    )
+      })
 
 
 class _AvroIntegrationTest(_IntegrationTest):
@@ -146,12 +143,12 @@ class TestRead(_AvroIntegrationTest):
   def test_read(self):
     self.client.upload('weather.avro', osp.join(self.dpath, 'weather.avro'))
     with AvroReader(self.client, 'weather.avro') as reader:
-      eq_(list(reader), self.records)
+      assert list(reader) == self.records
 
   def test_read_with_same_schema(self):
     self.client.upload('w.avro', osp.join(self.dpath, 'weather.avro'))
     with AvroReader(self.client, 'w.avro', reader_schema=self.schema) as reader:
-      eq_(list(reader), self.records)
+      assert list(reader) == self.records
 
   def test_read_with_compatible_schema(self):
     self.client.upload('w.avro', osp.join(self.dpath, 'weather.avro'))
@@ -164,10 +161,9 @@ class TestRead(_AvroIntegrationTest):
       ],
     }
     with AvroReader(self.client, 'w.avro', reader_schema=schema) as reader:
-      eq_(
-        list(reader),
-        [{'temp': r['temp'], 'tag': ''} for r in self.records]
-      )
+      assert (
+        list(reader) ==
+        [{'temp': r['temp'], 'tag': ''} for r in self.records])
 
 
 class TestWriter(_AvroIntegrationTest):
@@ -183,10 +179,9 @@ class TestWriter(_AvroIntegrationTest):
         writer.write(record)
     with temppath() as tpath:
       self.client.download('weather.avro', tpath)
-      eq_(
-        self._get_data_bytes(osp.join(self.dpath, 'weather.avro')),
-        self._get_data_bytes(tpath)
-      )
+      assert (
+        self._get_data_bytes(osp.join(self.dpath, 'weather.avro')) ==
+        self._get_data_bytes(tpath))
 
   def test_write_in_multiple_blocks(self):
     writer = AvroWriter(
@@ -199,14 +194,14 @@ class TestWriter(_AvroIntegrationTest):
       for record in self.records:
         writer.write(record)
     with AvroReader(self.client, 'weather.avro') as reader:
-      eq_(list(reader), self.records)
+      assert list(reader) == self.records
 
   def test_write_empty(self):
     with AvroWriter(self.client, 'empty.avro', schema=self.schema):
       pass
     with AvroReader(self.client, 'empty.avro') as reader:
-      eq_(reader.schema, self.schema)
-      eq_(list(reader), [])
+      assert reader.schema == self.schema
+      assert list(reader) == []
 
   @raises(HdfsError)
   def test_write_overwrite_error(self):
@@ -221,7 +216,7 @@ class TestWriter(_AvroIntegrationTest):
       for record in self.records:
         writer.write(record)
     with AvroReader(self.client, 'weather.avro') as reader:
-      eq_(list(reader), self.records)
+      assert list(reader) == self.records
 
 
 class TestMain(_AvroIntegrationTest):
@@ -233,7 +228,7 @@ class TestMain(_AvroIntegrationTest):
         main(['schema', 'weather.avro'], client=self.client, stdout=writer)
       with open(tpath) as reader:
         schema = load(reader)
-      eq_(self.schema, schema)
+      assert self.schema == schema
 
   def test_read(self):
     self.client.upload('weather.avro', osp.join(self.dpath, 'weather.avro'))
@@ -246,7 +241,7 @@ class TestMain(_AvroIntegrationTest):
         )
       with open(tpath) as reader:
         records = [loads(line) for line in reader]
-      eq_(records, self.records[:2])
+      assert records == self.records[:2]
 
   def test_read_part_file(self):
     data = {
@@ -266,7 +261,7 @@ class TestMain(_AvroIntegrationTest):
         )
       with open(tpath) as reader:
         records = [loads(line) for line in reader]
-      eq_(records, data['part-m-00001.avro'])
+      assert records == data['part-m-00001.avro']
 
   def test_write(self):
     with open(osp.join(self.dpath, 'weather.jsonl')) as reader:
@@ -281,10 +276,9 @@ class TestMain(_AvroIntegrationTest):
       )
     with temppath() as tpath:
       self.client.download('weather.avro', tpath)
-      eq_(
-        self._get_data_bytes(tpath),
-        self._get_data_bytes(osp.join(self.dpath, 'weather.avro'))
-      )
+      assert (
+        self._get_data_bytes(tpath) ==
+        self._get_data_bytes(osp.join(self.dpath, 'weather.avro')))
 
   def test_write_codec(self):
     with open(osp.join(self.dpath, 'weather.jsonl')) as reader:
@@ -300,8 +294,8 @@ class TestMain(_AvroIntegrationTest):
     # Correct content.
     with AvroReader(self.client, 'weather.avro') as reader:
       records = list(reader)
-    eq_(records, self.records)
+    assert records == self.records
     # Different size (might not be smaller, since very small file).
     compressed_size = self.client.content('weather.avro')['length']
     uncompressed_size = osp.getsize(osp.join(self.dpath, 'weather.avro'))
-    ok_(compressed_size != uncompressed_size)
+    assert compressed_size != uncompressed_size

--- a/test/test_ext_avro.py
+++ b/test/test_ext_avro.py
@@ -5,12 +5,10 @@
 
 from hdfs.util import HdfsError, temppath
 from json import dumps, load, loads
-from nose.plugins.skip import SkipTest
-from nose.tools import eq_, ok_, raises
 from util import _IntegrationTest
 import os
 import os.path as osp
-import sys
+import pytest
 
 try:
   from hdfs.ext.avro import (_SeekableReader, _SchemaInferrer, AvroReader,
@@ -26,7 +24,7 @@ class TestSeekableReader(object):
 
   def setup(self):
     if SKIP:
-      raise SkipTest
+      pytest.skip()
 
   def test_normal_read(self):
     with temppath() as tpath:
@@ -56,7 +54,8 @@ class TestInferSchema(object):
 
   def setup(self):
     if SKIP:
-      raise SkipTest
+      pytest.skip()
+
 
   def test_array(self):
     assert (
@@ -203,13 +202,13 @@ class TestWriter(_AvroIntegrationTest):
       assert reader.schema == self.schema
       assert list(reader) == []
 
-  @raises(HdfsError)
   def test_write_overwrite_error(self):
-    # To check that the background `AsyncWriter` thread doesn't hang.
-    self.client.makedirs('weather.avro')
-    with AvroWriter(self.client, 'weather.avro', schema=self.schema) as writer:
-      for record in self.records:
-        writer.write(record)
+    with pytest.raises(HdfsError):
+      # To check that the background `AsyncWriter` thread doesn't hang.
+      self.client.makedirs('weather.avro')
+      with AvroWriter(self.client, 'weather.avro', schema=self.schema) as writer:
+        for record in self.records:
+          writer.write(record)
 
   def test_infer_schema(self):
     with AvroWriter(self.client, 'weather.avro') as writer:

--- a/test/test_ext_dataframe.py
+++ b/test/test_ext_dataframe.py
@@ -52,7 +52,7 @@ class TestWriteDataFrame(_DataFrameIntegrationTest):
   def test_write(self):
     write_dataframe(self.client, 'weather.avro', self.df)
     with AvroReader(self.client, 'weather.avro') as reader:
-      eq_(list(reader), self.records)
+      assert list(reader) == self.records
 
 
 class TestReadWriteDataFrame(_DataFrameIntegrationTest):

--- a/test/test_ext_dataframe.py
+++ b/test/test_ext_dataframe.py
@@ -5,8 +5,6 @@
 
 from hdfs.util import HdfsError, temppath
 from json import loads
-from nose.plugins.skip import SkipTest
-from nose.tools import *
 from util import _IntegrationTest
 import os.path as osp
 

--- a/test/test_ext_dataframe.py
+++ b/test/test_ext_dataframe.py
@@ -5,7 +5,7 @@
 
 from hdfs.util import HdfsError, temppath
 from json import loads
-from util import _IntegrationTest
+from test.util import _IntegrationTest
 import os.path as osp
 
 try:

--- a/test/test_ext_kerberos.py
+++ b/test/test_ext_kerberos.py
@@ -3,7 +3,6 @@
 
 """Test Kerberos extension."""
 
-from nose.tools import eq_, ok_
 from threading import Lock, Thread
 from time import sleep, time
 import sys

--- a/test/test_ext_kerberos.py
+++ b/test/test_ext_kerberos.py
@@ -18,12 +18,12 @@ class MockHTTPKerberosAuth(object):
 
   def __call__(self, n):
     with self._lock:
-      ok_(not self._items)
+      assert not self._items
       self._items.append(n)
     sleep(0.25)
     with self._lock:
       thread = self._items.pop()
-      eq_(thread, n)
+      assert thread == n
       self._calls.add(thread)
 
 
@@ -47,4 +47,4 @@ class TestKerberosClient(object):
     t2.start()
     t1.join()
     t2.join()
-    eq_(auth._calls, {1, 2})
+    assert auth._calls == {1, 2}

--- a/test/test_ext_kerberos.py
+++ b/test/test_ext_kerberos.py
@@ -3,7 +3,7 @@
 
 """Test Kerberos extension."""
 
-from nose.tools import eq_, nottest, ok_, raises
+from nose.tools import eq_, ok_
 from threading import Lock, Thread
 from time import sleep, time
 import sys

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -24,15 +24,15 @@ class TestParseArg(object):
       parse_arg({'foo': 'a'}, 'foo', int)
 
   def test_parse_int(self):
-    eq_(parse_arg({'foo': '1'}, 'foo', int), 1)
-    eq_(parse_arg({'foo': '1'}, 'foo', int, ','), 1)
+    assert parse_arg({'foo': '1'}, 'foo', int) == 1
+    assert parse_arg({'foo': '1'}, 'foo', int, ',') == 1
 
   def test_parse_float(self):
-    eq_(parse_arg({'foo': '123.4'}, 'foo', float), 123.4)
+    assert parse_arg({'foo': '123.4'}, 'foo', float) == 123.4
 
   def test_parse_int_list(self):
-    eq_(parse_arg({'foo': '1,'}, 'foo', int, ','), [1])
-    eq_(parse_arg({'foo': '1,2'}, 'foo', int, ','), [1,2])
+    assert parse_arg({'foo': '1,'}, 'foo', int, ',') == [1]
+    assert parse_arg({'foo': '1,2'}, 'foo', int, ',') == [1,2]
 
 
 class TestConfigureClient(object):
@@ -46,8 +46,8 @@ class TestConfigureClient(object):
       config.set(section, 'url', url)
       args = {'--alias': 'dev', '--log': False, '--verbose': 0}
       client = configure_client('test', args, config=config)
-      eq_(client.url, url)
-      eq_(client.urls, [url])
+      assert client.url == url
+      assert client.urls == [url]
 
 
 class TestProgress(object):
@@ -57,13 +57,13 @@ class TestProgress(object):
       with open(tpath, 'w') as writer:
         progress = _Progress(100, 1, writer=writer)
         progress('foo', 60)
-        eq_(progress._data['foo'], 60)
-        eq_(progress._pending_files, 0)
-        eq_(progress._downloading_files, 1)
+        assert progress._data['foo'] == 60
+        assert progress._pending_files == 0
+        assert progress._downloading_files == 1
         progress('foo', 40)
         progress('foo', -1)
-        eq_(progress._downloading_files, 0)
-        eq_(progress._complete_files, 1)
+        assert progress._downloading_files == 0
+        assert progress._complete_files == 1
 
   def test_from_local_path(self):
     with temppath() as dpath:
@@ -78,8 +78,8 @@ class TestProgress(object):
       with temppath() as tpath:
         with open(tpath, 'w') as writer:
           progress = _Progress.from_local_path(dpath, writer=writer)
-          eq_(progress._total_bytes, 8)
-          eq_(progress._pending_files, 2)
+          assert progress._total_bytes == 8
+          assert progress._pending_files == 2
 
 
 class TestMain(_IntegrationTest):
@@ -96,9 +96,9 @@ class TestMain(_IntegrationTest):
 
   def _dircmp(self, dpath):
     dircmp = filecmp.dircmp(self.dpath, dpath)
-    ok_(not dircmp.left_only)
-    ok_(not dircmp.right_only)
-    ok_(not dircmp.diff_files)
+    assert not dircmp.left_only
+    assert not dircmp.right_only
+    assert not dircmp.diff_files
 
   def test_download(self):
     self.client.upload('foo', self.dpath)
@@ -123,7 +123,7 @@ class TestMain(_IntegrationTest):
       finally:
         sys.stdout = stdout
       with open(tpath) as reader:
-        eq_(reader.read(), 'hello')
+        assert reader.read() == 'hello'
 
   def test_download_stream_multiple_files(self):
     with pytest.raises(SystemExit):
@@ -155,7 +155,7 @@ class TestMain(_IntegrationTest):
         self.client
       )
       with open(tpath) as reader:
-        eq_(reader.read(), 'hey')
+        assert reader.read() == 'hey'
 
   def test_upload(self):
     main(
@@ -194,7 +194,7 @@ class TestMain(_IntegrationTest):
         self.client
       )
     with self.client.read('bar') as reader:
-      eq_(reader.read(), b'heyhey')
+      assert reader.read() == b'heyhey'
 
   def test_upload_append_folder(self):
     with pytest.raises(SystemExit):

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -85,12 +85,12 @@ class TestMain(_IntegrationTest):
 
   dpath = osp.join(osp.dirname(__file__), 'dat')
 
-  def setup(self):
+  def setup_method(self):
     self._root_logger = lg.getLogger()
     self._handlers = self._root_logger.handlers
-    super(TestMain, self).setup()
+    super(TestMain, self).setup_method()
 
-  def teardown(self):
+  def teardown_method(self):
     self._root_logger.handlers = self._handlers
 
   def _dircmp(self, dpath):

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -7,20 +7,21 @@ from hdfs.__main__ import _Progress, configure_client, main, parse_arg
 from hdfs.config import Config, NullHandler
 from hdfs.util import HdfsError, temppath
 from logging.handlers import TimedRotatingFileHandler
-from nose.tools import eq_, nottest, ok_, raises
+from nose.tools import eq_, ok_
 from util import _IntegrationTest, save_config
 import filecmp
 import logging as lg
 import os
 import os.path as osp
+import pytest
 import sys
 
 
 class TestParseArg(object):
 
-  @raises(HdfsError)
   def test_parse_invalid(self):
-    parse_arg({'foo': 'a'}, 'foo', int)
+    with pytest.raises(HdfsError):
+      parse_arg({'foo': 'a'}, 'foo', int)
 
   def test_parse_int(self):
     eq_(parse_arg({'foo': '1'}, 'foo', int), 1)
@@ -124,25 +125,25 @@ class TestMain(_IntegrationTest):
       with open(tpath) as reader:
         eq_(reader.read(), 'hello')
 
-  @raises(SystemExit)
   def test_download_stream_multiple_files(self):
-    self.client.upload('foo', self.dpath)
-    main(
-      ['download', 'foo', '-', '--silent', '--threads', '1'],
-      self.client
-    )
-
-  @raises(SystemExit)
-  def test_download_overwrite(self):
-    self.client.upload('foo', self.dpath)
-    with temppath() as tpath:
-      with open(tpath, 'w'):
-        pass
+    with pytest.raises(SystemExit):
+      self.client.upload('foo', self.dpath)
       main(
-        ['download', 'foo', tpath, '--silent', '--threads', '1'],
+        ['download', 'foo', '-', '--silent', '--threads', '1'],
         self.client
       )
-      self._dircmp(tpath)
+
+  def test_download_overwrite(self):
+    with pytest.raises(SystemExit):
+      self.client.upload('foo', self.dpath)
+      with temppath() as tpath:
+        with open(tpath, 'w'):
+          pass
+        main(
+          ['download', 'foo', tpath, '--silent', '--threads', '1'],
+          self.client
+        )
+        self._dircmp(tpath)
 
   def test_download_force(self):
     self.client.write('foo', 'hey')
@@ -165,13 +166,13 @@ class TestMain(_IntegrationTest):
       self.client.download('bar', tpath)
       self._dircmp(tpath)
 
-  @raises(SystemExit)
   def test_upload_overwrite(self):
-    self.client.write('bar', 'hey')
-    main(
-      ['upload', self.dpath, 'bar', '--silent', '--threads', '1'],
-      self.client
-    )
+    with pytest.raises(SystemExit):
+      self.client.write('bar', 'hey')
+      main(
+        ['upload', self.dpath, 'bar', '--silent', '--threads', '1'],
+        self.client
+      )
 
   def test_upload_force(self):
     self.client.write('bar', 'hey')
@@ -195,7 +196,7 @@ class TestMain(_IntegrationTest):
     with self.client.read('bar') as reader:
       eq_(reader.read(), b'heyhey')
 
-  @raises(SystemExit)
   def test_upload_append_folder(self):
-    with temppath() as tpath:
-      main(['upload', self.dpath, '--silent', '--append'], self.client)
+    with pytest.raises(SystemExit):
+      with temppath() as tpath:
+        main(['upload', self.dpath, '--silent', '--append'], self.client)

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -7,7 +7,7 @@ from hdfs.__main__ import _Progress, configure_client, main, parse_arg
 from hdfs.config import Config, NullHandler
 from hdfs.util import HdfsError, temppath
 from logging.handlers import TimedRotatingFileHandler
-from util import _IntegrationTest, save_config
+from test.util import _IntegrationTest
 import filecmp
 import logging as lg
 import os

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -7,7 +7,6 @@ from hdfs.__main__ import _Progress, configure_client, main, parse_arg
 from hdfs.config import Config, NullHandler
 from hdfs.util import HdfsError, temppath
 from logging.handlers import TimedRotatingFileHandler
-from nose.tools import eq_, ok_
 from util import _IntegrationTest, save_config
 import filecmp
 import logging as lg

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -16,7 +16,7 @@ class TestAsyncWriter(object):
     with AsyncWriter(consumer) as writer:
       writer.write('one')
       writer.write('two')
-    eq_(result, [['one','two']])
+    assert result == [['one','two']]
 
   def test_multiple_writer_uses(self):
     result = []
@@ -29,7 +29,7 @@ class TestAsyncWriter(object):
     with writer:
       writer.write('three')
       writer.write('four')
-    eq_(result, [['one','two'],['three','four']])
+    assert result == [['one','two'],['three','four']]
 
   def test_multiple_consumer_uses(self):
     result = []
@@ -41,7 +41,7 @@ class TestAsyncWriter(object):
     with AsyncWriter(consumer) as writer:
       writer.write('three')
       writer.write('four')
-    eq_(result, [['one','two'],['three','four']])
+    assert result == [['one','two'],['three','four']]
 
   @raises(ValueError)
   def test_nested(self):
@@ -79,16 +79,16 @@ class TestTemppath(object):
 
   def test_new(self):
     with temppath() as tpath:
-      ok_(not osp.exists(tpath))
+      assert not osp.exists(tpath)
 
   def test_cleanup(self):
     with temppath() as tpath:
       with open(tpath, 'w') as writer:
         writer.write('hi')
-    ok_(not osp.exists(tpath))
+    assert not osp.exists(tpath)
 
   def test_dpath(self):
     with temppath() as dpath:
       os.mkdir(dpath)
       with temppath(dpath) as tpath:
-        eq_(osp.dirname(tpath), dpath)
+        assert osp.dirname(tpath) == dpath

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -4,7 +4,7 @@
 """Test Hdfs client interactions with HDFS."""
 
 from hdfs.util import *
-from nose.tools import eq_, ok_, raises
+import pytest
 
 
 class TestAsyncWriter(object):
@@ -43,36 +43,36 @@ class TestAsyncWriter(object):
       writer.write('four')
     assert result == [['one','two'],['three','four']]
 
-  @raises(ValueError)
   def test_nested(self):
-    result = []
-    def consumer(gen):
-      result.append(list(gen))
-    with AsyncWriter(consumer) as _writer:
-      _writer.write('one')
-      with _writer as writer:
+    with pytest.raises(ValueError):
+      result = []
+      def consumer(gen):
+        result.append(list(gen))
+      with AsyncWriter(consumer) as _writer:
+        _writer.write('one')
+        with _writer as writer:
+          writer.write('two')
+
+  def test_child_error(self):
+    with pytest.raises(HdfsError):
+      def consumer(gen):
+        for value in gen:
+          if value == 'two':
+            raise HdfsError('Yo')
+      with AsyncWriter(consumer) as writer:
+        writer.write('one')
         writer.write('two')
 
-  @raises(HdfsError)
-  def test_child_error(self):
-    def consumer(gen):
-      for value in gen:
-        if value == 'two':
-          raise HdfsError('Yo')
-    with AsyncWriter(consumer) as writer:
-      writer.write('one')
-      writer.write('two')
-
-  @raises(HdfsError)
   def test_parent_error(self):
-    def consumer(gen):
-      for value in gen:
-        pass
-    def invalid(w):
-      w.write('one')
-      raise HdfsError('Ya')
-    with AsyncWriter(consumer) as writer:
-      invalid(writer)
+    with pytest.raises(HdfsError):
+      def consumer(gen):
+        for value in gen:
+          pass
+      def invalid(w):
+        w.write('one')
+        raise HdfsError('Ya')
+      with AsyncWriter(consumer) as writer:
+        invalid(writer)
 
 
 class TestTemppath(object):

--- a/test/util.py
+++ b/test/util.py
@@ -6,13 +6,12 @@
 from hdfs import InsecureClient
 from hdfs.config import Config
 from hdfs.util import HdfsError
-from nose.plugins.skip import SkipTest
-from nose.tools import eq_
 from requests.exceptions import ConnectionError
 from six.moves.configparser import NoOptionError, NoSectionError
 from time import sleep
 import os
 import posixpath as psp
+import pytest
 
 
 def save_config(config, path=None):
@@ -65,7 +64,7 @@ class _IntegrationTest(object):
 
   def setup(self):
     if not self.client:
-      raise SkipTest
+      pytest.skip()
     else:
       try:
         self.client.delete('', recursive=True)

--- a/test/util.py
+++ b/test/util.py
@@ -62,7 +62,7 @@ class _IntegrationTest(object):
     if cls.client:
       cls.client.delete('', recursive=True)
 
-  def setup(self):
+  def setup_method(self):
     if not self.client:
       pytest.skip()
     else:


### PR DESCRIPTION
I believe this is done since there are no more warnings from pytest about deprecated nose compatibility features.

I tested locally in the WebHDFS variant (according to the skipped test count, which was 4). I couldn't figure out how to test using the HTTPFS variant.

Fixes #190

Edit:
There are 4 additional tests being run now, due to the added pandas dependency: 3 in test_ext_dataframe.py and 1 in dataframe-example.py. There are also 4 additional tests that are being skipped in pytest, but were annotated `@nottest` in nose.