### PR TITLE
Fix typos

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -56,7 +56,7 @@ Breaking changes:
   Setting `chunk_size` to a positive value will make it return a generator 
   similar to the previous behavior.
 * Rename `Client.set_permissions` to `Client.set_permission` to make 
-  `permission` argument uniform across `Client` methods (alway singular, 
+  `permission` argument uniform across `Client` methods (always singular, 
   consistent with WebHDFS API).
 * `Client.parts` will now throw an error if called on a normal file.
 * Make most client attributes private (e.g. `cert`, `timeout`, etc.), except 
@@ -94,7 +94,7 @@ Version 1.4.0 (2015/07/24)
 Version 1.1.0 (2015/06/23)
 --------------------------
 
-* Rename Avro extention entry point to `hdfs-avro`.
+* Rename Avro extension entry point to `hdfs-avro`.
 
 
 Version 1.0.1 (2015/06/17)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -316,7 +316,7 @@ epub_copyright = u'2014, Author'
 # The format is a list of tuples containing the path and title.
 #epub_pre_files = []
 
-# HTML files shat should be inserted after the pages created by sphinx.
+# HTML files that should be inserted after the pages created by sphinx.
 # The format is a list of tuples containing the path and title.
 #epub_post_files = []
 

--- a/hdfs/client.py
+++ b/hdfs/client.py
@@ -202,7 +202,7 @@ class Client(object):
     :param method: HTTP verb.
     :param url: Url to send the request to.
     :param \*\*kwargs: Extra keyword arguments forwarded to the request
-      handler. If any `params` are defined, these will take precendence over
+      handler. If any `params` are defined, these will take precedence over
       the instance's defaults.
 
     """
@@ -1040,7 +1040,7 @@ class Client(object):
   def allow_snapshot(self, hdfs_path):
     """Allow snapshots for a remote folder.
 
-    :param hdfs_path: Remote path to a direcotry.  If `hdfs_path`
+    :param hdfs_path: Remote path to a directory.  If `hdfs_path`
       doesn't exist or does points to a normal file, an
       :class:`HdfsError` will be raised.  No-op if snapshotting is
       already allowed.
@@ -1052,7 +1052,7 @@ class Client(object):
   def disallow_snapshot(self, hdfs_path):
     """Disallow snapshots for a remote folder.
 
-    :param hdfs_path: Remote path to a direcotry.  If `hdfs_path`
+    :param hdfs_path: Remote path to a directory.  If `hdfs_path`
       doesn't exist, points to a normal file or there are some
       snapshots, an :class:`HdfsError` will be raised.
 
@@ -1065,7 +1065,7 @@ class Client(object):
   def create_snapshot(self, hdfs_path, snapshotname=None):
     """Create snapshot for a remote folder where it was allowed.
 
-    :param hdfs_path: Remote path to a direcotry.  If `hdfs_path`
+    :param hdfs_path: Remote path to a directory.  If `hdfs_path`
       doesn't exist, doesn't allow to create snapshot or points to a
       normal file, an :class:`HdfsError` will be raised.
     :param snapshotname snapshot name; if absent, name is generated
@@ -1080,7 +1080,7 @@ class Client(object):
   def delete_snapshot(self, hdfs_path, snapshotname):
     """Remove snapshot for a remote folder where it was allowed.
 
-    :param hdfs_path: Remote path to a direcotry.  If `hdfs_path` doesn't exist
+    :param hdfs_path: Remote path to a directory.  If `hdfs_path` doesn't exist
       or points to a normal file, an :class:`HdfsError` will be raised.
     :param snapshotname snapshot name; if it does not exist, an
       :class:`HdfsError` will be raised.
@@ -1092,7 +1092,7 @@ class Client(object):
   def rename_snapshot(self, hdfs_path, oldsnapshotname, snapshotname):
     """Rename snapshot for a remote folder.
 
-    :param hdfs_path: Remote path to a direcotry.  If `hdfs_path` doesn't exist
+    :param hdfs_path: Remote path to a directory.  If `hdfs_path` doesn't exist
       or points to a normal file, an :class:`HdfsError` will be raised.
     :param oldsnapshotname snapshot name; if it does not exist,
       an :class:`HdfsError` will be raised.


### PR DESCRIPTION
Found via `codespell -L fo`