### PR TITLE
Exclude tests from find_packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
   author_email='mtth@apache.org',
   url='https://hdfscli.readthedocs.io',
   license='MIT',
-  packages=find_packages(),
+  packages=find_packages(exclude=['test*']),
   classifiers=[
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',


### PR DESCRIPTION
Fixes #201.

Tests are still present in the sdist.