### PR TITLE
Replace imp.load_source()

### DIFF
--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -4,18 +4,12 @@
 """Test that the examples run correctly."""
 
 from hdfs import Config
+from hdfs.config import _load_source
 from six import add_metaclass
 from test.util import _IntegrationTest
 import os
 import os.path as osp
 import pytest
-
-try:
-  # Python 3.12 and above
-  from importlib import load_source
-except ImportError:
-  # Below Python 3.12
-  from imp import load_source
 
 class _ExamplesType(type):
 
@@ -31,7 +25,7 @@ class _ExamplesType(type):
 
       def test(self):
         try:
-          load_source(module, fpath)
+          _load_source(module, fpath)
         except ImportError:
           # Unmet dependency.
           pytest.skip()


### PR DESCRIPTION
Fix #203.

This is straight out of https://docs.python.org/3.12/whatsnew/3.12.html, as suggested in https://github.com/mtth/hdfs/issues/203#issuecomment-1672388410, with the choice to cache in `sys.modules` so re-imported modules are not multiply-executed.

Nothing explodes when I run the tests, but I haven’t attempted to set up a test cluster, so a lot of tests are skipped.