### PR TITLE
Adjust Sphinx copyright strings to “<YEAR>, <AUTHOR>” form

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -55,7 +55,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'HdfsCLI'
-copyright = u'2014'
+copyright = u'2014, Matthieu Monsch'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -281,7 +281,7 @@ texinfo_documents = [
 epub_title = u'hdfs'
 epub_author = u'Author'
 epub_publisher = u'Author'
-epub_copyright = u'2014, Author'
+epub_copyright = u'2014, Matthieu Monsch'
 
 # The basename for the epub file. It defaults to the project name.
 #epub_basename = u'hdfs'


### PR DESCRIPTION
This is the form [documented upstream](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-copyright), and as of Sphinx 7.1 this form is [required when the `SOURCE_DATE_EPOCH` environment variable is set](https://bugzilla.redhat.com/show_bug.cgi?id=2232580#c4).

I noticed that these strings have a copyright date of 2014 while `LICENSE` has 2013. If you like, I can also adjust them to match `LICENSE`.