### PR TITLE
Allow overwrites during rename. This is required for doing atomic puts.

### DIFF
--- a/hdfs/client.py
+++ b/hdfs/client.py
@@ -924,7 +924,7 @@ class Client(object):
     _logger.info('%r moved to trash at %r.', hdfs_path, dst_path)
     return True
 
-  def rename(self, hdfs_src_path, hdfs_dst_path):
+  def rename(self, hdfs_src_path, hdfs_dst_path, overwrite=False):
     """Move a file or folder.
 
     :param hdfs_src_path: Source path.
@@ -932,11 +932,14 @@ class Client(object):
       a directory, the source will be moved into it. If the path exists and is
       a file, or if a parent destination directory is missing, this method will
       raise an :class:`HdfsError`.
+    :param overwrite: overwrite the hdfs_dst_path if it already exists, rather
+      than raising an :class:`HdfsError`.
 
     """
     _logger.info('Renaming %r to %r.', hdfs_src_path, hdfs_dst_path)
     hdfs_dst_path = self.resolve(hdfs_dst_path)
-    res = self._rename(hdfs_src_path, destination=hdfs_dst_path)
+    kwargs = {"renameoptions": "overwrite"} if overwrite else {}
+    res = self._rename(hdfs_src_path, destination=hdfs_dst_path, **kwargs)
     if not res.json()['boolean']:
       raise HdfsError(
         'Unable to rename %r to %r.',


### PR DESCRIPTION
To implement atomic writes/puts, you need to write to a temporary file (non-atomic operation) and then rename the temporary file to the destination in a single (atomic) operation. Since rename does not currently support this (i.e. if the destination file already exists rename will fail and thus a delete and then rename is required, which is not atomic), added an option to pass the `renameoptions="overwrite"` to the WebHDFS rename API. This is received by this code here: https://github.com/apache/hadoop/blob/trunk/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/web/resources/NamenodeWebHdfsMethods.java#L749

Which in turn calls: https://github.com/apache/hadoop/blob/trunk/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/ClientProtocol.java#L545

Which is documented as being atomic.

Haven't updated or run any hdfs tests - this is tested and works though in my own code base.
